### PR TITLE
fixed issue with login sometimes failing with a console error

### DIFF
--- a/.github/workflows/on-merge-develop.yml
+++ b/.github/workflows/on-merge-develop.yml
@@ -22,6 +22,7 @@ name: Deploy QA
 env:
   FUNCTION_APP_DIR: 'src/API/WesternStatesWater.WestDaat.Client.Functions'
   REACT_APP_WEBAPI_URL: 'https://westdaat-qa.azurewebsites.net/api/'
+  REACT_APP_AUTH_REDIRECT_URL: 'https://westdaatqa.azureedge.net/authredirect.html' # the URL used by Azure B2C to redirect to your app after login
   AZURE_RESOURCE_GROUP: WestDAAT_QA           # set the resource group name
   AZURE_FUNCTIONAPP_NAME: westdaat-qa         # set this to the name of your Azure Web App
   AZURE_STORAGE_ACCOUNT_NAME: westdaatqa      # set the storage account of static site

--- a/src/DashboardUI/.env
+++ b/src/DashboardUI/.env
@@ -1,2 +1,5 @@
 REACT_APP_MAPBOX_ACCESSTOKEN=pk.eyJ1IjoiYW1hYmRhbGxhaCIsImEiOiJjazJnbno5ZHIwazVqM21xZzMwaWpsc2hqIn0.j6BmkJdp5O_9ITGm4Gwe0w
 REACT_APP_WEBAPI_URL=http://localhost:5001/api/
+# Per this github issue the redirect page must be outside the react router or it will create a race condition between MSAL trying to grab a hash off the URL and the router trying to clear the hash
+# https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4573
+REACT_APP_AUTH_REDIRECT_URL=http://localhost:3000/authredirect.html

--- a/src/DashboardUI/public/authRedirect.html
+++ b/src/DashboardUI/public/authRedirect.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Western States Water Data Access and Analysis Tool (WestDAAT)</title>
+</head>
+
+<body>
+  Processing...
+</body>
+
+</html>

--- a/src/DashboardUI/src/authConfig.tsx
+++ b/src/DashboardUI/src/authConfig.tsx
@@ -5,7 +5,7 @@ export const msalConfig : Configuration = {
     clientId: "ab3cf308-8a7e-404e-977c-d0227f4a48c4",
     authority: "https://westdaatqa.b2clogin.com/westdaatqa.onmicrosoft.com/b2c_1_signupsignin", // This is a URL (e.g. https://login.microsoftonline.com/{your tenant ID})
     knownAuthorities: ["https://westdaatqa.b2clogin.com/westdaatqa.onmicrosoft.com"],
-    redirectUri: "/",
+    redirectUri: process.env.REACT_APP_AUTH_REDIRECT_URL,
   },
   cache: {
     cacheLocation: "sessionStorage", // This configures where your cache will be stored


### PR DESCRIPTION
There is an issue where the react router will strip the hash value that MSAL needs on the login redirect. Per this github issue the fix is to create a "blank" html page that lives outside of the react router, e.g. in the /public folder.
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4573