### PR TITLE
Changing map style on details page to be satellite

### DIFF
--- a/src/DashboardUI/src/components/SiteMap.tsx
+++ b/src/DashboardUI/src/components/SiteMap.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from "react";
 import Map from './Map';
-import { MapContext } from './MapProvider';
+import { MapContext, MapStyle } from './MapProvider';
 import mapboxgl from 'mapbox-gl';
 import { useWaterSiteLocation } from "../hooks";
 import { Position } from "geojson";
@@ -20,7 +20,12 @@ function SiteMap(props: siteMapProps) {
     setGeoJsonData,
     setMapBoundSettings: setMapBounds,
     setLegend,
+    setMapStyle
   } = useContext(MapContext);
+
+  useEffect(() => {
+    setMapStyle(MapStyle.Satellite);
+  }, [setMapStyle])
 
   useEffect(() => {
     setVisibleLayers(["site-locations-label", "site-locations-points", "site-locations-polygons"]);

--- a/src/DashboardUI/src/components/WaterRightMap.tsx
+++ b/src/DashboardUI/src/components/WaterRightMap.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from "react";
 import Map from './Map';
-import { MapContext } from './MapProvider';
+import { MapContext, MapStyle } from './MapProvider';
 import mapboxgl from 'mapbox-gl';
 import { useWaterRightSiteLocations } from "../hooks";
 import { Position } from "geojson";
@@ -20,11 +20,16 @@ function WaterRightMap(props: waterRightMapProps) {
     setGeoJsonData,
     setMapBoundSettings: setMapBounds,
     setLegend,
+    setMapStyle
   } = useContext(MapContext);
 
   useEffect(() => {
     setVisibleLayers(["site-locations-label", "site-locations-points", "site-locations-polygons"]);
   }, [setVisibleLayers])
+
+  useEffect(() => {
+    setMapStyle(MapStyle.Satellite);
+  }, [setMapStyle])
 
   useEffect(() => {
     setLegend(<>

--- a/src/DashboardUI/src/config/constants.ts
+++ b/src/DashboardUI/src/config/constants.ts
@@ -8,8 +8,8 @@ export const nldi = {
     epa: '#D55E00',
     unknown: '#CC79A7',
     riverBasin: '#088',
-    sitePOD: '#01579b',
-    sitePOU: '#7cb342',
+    sitePOD: '#00CEFF',
+    sitePOU: '#32CD32',
   },
   latLongPrecision: 4,
 };

--- a/src/DashboardUI/src/config/maps.ts
+++ b/src/DashboardUI/src/config/maps.ts
@@ -147,7 +147,7 @@ const mapsJson = {
       "paint": {
         "text-color": "#000000",
         "text-halo-color": "#ffffff",
-        "text-halo-width": 0.5,
+        "text-halo-width": 2,
       },
     },
     {


### PR DESCRIPTION
Set map style as satellite
changed marker colors to match mockup and be more visible

![image](https://user-images.githubusercontent.com/17817921/175094979-7cf5110e-c4f5-45d1-b720-807781d71d2f.png)
![image](https://user-images.githubusercontent.com/17817921/175095054-207ca93e-d894-4970-809f-fe8fbcc0e199.png)
