### PR TITLE
Skenny/piechart UI

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Managers/WaterAllocationManager.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/WaterAllocationManager.cs
@@ -58,7 +58,7 @@ namespace WesternStatesWater.WestDaat.Managers
             var accessorSearchRequest = searchRequest.Map<WaterRightsSearchCriteria>();
 
             var geometryFilters = new List<NetTopologySuite.Geometries.Geometry>();
-            if (searchRequest.RiverBasinNames?.Any() ?? false)
+            if (searchRequest?.RiverBasinNames?.Any() ?? false)
             {
                 var featureCollection = _locationEngine.GetRiverBasinPolygonsByName(searchRequest.RiverBasinNames);
                 var riverBasinPolygons = GeometryHelpers.GetGeometryByFeatures(featureCollection.Features);

--- a/src/DashboardUI/package-lock.json
+++ b/src/DashboardUI/package-lock.json
@@ -61,7 +61,9 @@
       "devDependencies": {
         "@types/chroma-js": "^2.1.3",
         "@types/mapbox-gl": "^2.6.1",
-        "@types/validator": "^13.7.2"
+        "@types/validator": "^13.7.2",
+        "highcharts": "^10.2.0",
+        "highcharts-react-official": "^3.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9041,6 +9043,22 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highcharts": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.0.tgz",
+      "integrity": "sha512-MvLo4dzR2Vo7Y85dsqJ07uabBXSSIRKRRdW4l9IGP55h2jYWNm/m9JBszVVxySH5Lda6g+Ins9NdGppZJpjNCA==",
+      "dev": true
+    },
+    "node_modules/highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "dev": true,
+      "peerDependencies": {
+        "highcharts": ">=6.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/history": {
@@ -24640,6 +24658,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "highcharts": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.0.tgz",
+      "integrity": "sha512-MvLo4dzR2Vo7Y85dsqJ07uabBXSSIRKRRdW4l9IGP55h2jYWNm/m9JBszVVxySH5Lda6g+Ins9NdGppZJpjNCA==",
+      "dev": true
+    },
+    "highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "dev": true,
+      "requires": {}
     },
     "history": {
       "version": "5.2.0",

--- a/src/DashboardUI/package.json
+++ b/src/DashboardUI/package.json
@@ -80,6 +80,8 @@
   "devDependencies": {
     "@types/chroma-js": "^2.1.3",
     "@types/mapbox-gl": "^2.6.1",
-    "@types/validator": "^13.7.2"
+    "@types/validator": "^13.7.2",
+    "highcharts": "^10.2.0",
+    "highcharts-react-official": "^3.1.0"
   }
 }

--- a/src/DashboardUI/src/accessors/waterAllocationAccessor.ts
+++ b/src/DashboardUI/src/accessors/waterAllocationAccessor.ts
@@ -4,6 +4,7 @@ import {
   WaterSourceInfoListItem,
 } from '@data-contracts';
 import axios from 'axios';
+import { AnalyticsSummaryInformation } from '../data-contracts/AnalyticsSummaryInformation';
 import { WaterRightsSearchCriteria } from '../data-contracts/WaterRightsSearchCriteria';
 import { WaterRightsSearchResults } from '../data-contracts/WaterRightsSearchResults';
 
@@ -11,6 +12,11 @@ export const getWaterRightDetails = async (allocationUuid: string) => {
   const { data } = await axios.get<WaterRightDetails>(
     `${process.env.REACT_APP_WEBAPI_URL}WaterRights/${allocationUuid}`
   );
+  return data;
+};
+
+export const getWaterRightAnalyticsSummaryInfo = async (searchCriteria: WaterRightsSearchCriteria) => {
+  const { data } = await axios.post<AnalyticsSummaryInformation[]>(`${process.env.REACT_APP_WEBAPI_URL}WaterRights/AnalyticsSummaryInformation`, searchCriteria);
   return data;
 };
 

--- a/src/DashboardUI/src/components/PieChart.tsx
+++ b/src/DashboardUI/src/components/PieChart.tsx
@@ -1,0 +1,76 @@
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { Col, Row } from 'react-bootstrap';
+import { AnalyticsSummaryInformation } from '../data-contracts/AnalyticsSummaryInformation';
+
+interface PieChartProps {
+    data: AnalyticsSummaryInformation[] | undefined;
+}
+
+function PieChart(props: PieChartProps) {
+
+    const flowOptions = {
+        chart: {
+            type: 'pie',
+        },
+        title: {
+            text: 'Cumulative Flow (CFS) of Rendered Sites'
+        },
+        tooltip: {
+            pointFormat: '<b>{point.percentage:.1f}%</b>'
+        },
+        series: [
+            {
+                data: props.data?.map(x => [x.primaryUseCategoryName, x.flow])
+            }
+        ]
+    };
+
+    const countOptions = {
+        chart: {
+            type: 'pie',
+        },
+        title: {
+            text: 'Count of Rendered Points'
+        },
+        tooltip: {
+            pointFormat: '<b>{point.percentage:.1f}%</b>'
+        },
+        series: [
+            {
+                data: props.data?.map(x => [x.primaryUseCategoryName, x.points])
+            }
+        ]
+    };
+    const volumeOptions = {
+        chart: {
+            type: 'pie',
+        },
+        title: {
+            text: 'Cumulative Volume (AF) of Rendered Sites'
+        },
+        tooltip: {
+            pointFormat: '<b>{point.percentage:.1f}%</b>'
+        },
+        series: [
+            {
+                data: props.data?.map(x => [x.primaryUseCategoryName, x.points])
+            }
+        ]
+    };
+
+    return <div>
+        <Row>
+            <Col lg="4"><HighchartsReact highcharts={Highcharts} options={countOptions} />
+            </Col>
+            <Col lg="4">
+                <HighchartsReact highcharts={Highcharts} options={flowOptions} />
+            </Col>
+            <Col lg="4"><HighchartsReact highcharts={Highcharts} options={volumeOptions} />
+            </Col>
+        </Row>
+
+    </div>
+};
+
+export default PieChart;

--- a/src/DashboardUI/src/components/PieChart.tsx
+++ b/src/DashboardUI/src/components/PieChart.tsx
@@ -1,13 +1,31 @@
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import { Col, Row } from 'react-bootstrap';
+import { colorList } from '../config/constants';
 import { AnalyticsSummaryInformation } from '../data-contracts/AnalyticsSummaryInformation';
+import { useBeneficialUses } from '../hooks/useSystemQuery';
 
 interface PieChartProps {
-    data: AnalyticsSummaryInformation[] | undefined;
+    dataByBeneficialUse: AnalyticsSummaryInformation[] | undefined;
 }
 
 function PieChart(props: PieChartProps) {
+    const { data: allBeneficialUses } = useBeneficialUses();
+
+    let colorIndex = 0;
+    let colorMapping: { key: string, color: string }[];
+    colorMapping = allBeneficialUses?.map(a => ({ key: a.beneficialUseName, color: colorList[colorIndex++ % colorList.length] })) ?? [];
+
+    let flowSum = 0;
+    let volumeSum = 0;
+    let pointSum = 0;
+    props.dataByBeneficialUse?.forEach(x => {
+        const currentColor = (colorMapping.find(color => color.key == x.primaryUseCategoryName));
+        x.color = currentColor?.color || colorMapping.find(color => color.key == 'Unspecified')?.color;
+        flowSum += x.flow || 0;
+        volumeSum += x.volume || 0;
+        pointSum += x.points || 0;
+    })
 
     const flowOptions = {
         chart: {
@@ -16,12 +34,15 @@ function PieChart(props: PieChartProps) {
         title: {
             text: 'Cumulative Flow (CFS) of Rendered Sites'
         },
+        subtitle: {
+            text: `${flowSum.toFixed(2)} (CFS)`
+        },
         tooltip: {
             pointFormat: '<b>{point.percentage:.1f}%</b>'
         },
         series: [
             {
-                data: props.data?.map(x => [x.primaryUseCategoryName, x.flow])
+                data: props.dataByBeneficialUse?.map(x => ({ name: x.primaryUseCategoryName, y: x.flow, color: x.color }))
             }
         ]
     };
@@ -33,12 +54,15 @@ function PieChart(props: PieChartProps) {
         title: {
             text: 'Count of Rendered Points'
         },
+        subtitle: {
+            text: `${pointSum} Sites`
+        },
         tooltip: {
             pointFormat: '<b>{point.percentage:.1f}%</b>'
         },
         series: [
             {
-                data: props.data?.map(x => [x.primaryUseCategoryName, x.points])
+                data: props.dataByBeneficialUse?.map(x => ({ name: x.primaryUseCategoryName, y: x.points, color: x.color }))
             }
         ]
     };
@@ -49,24 +73,32 @@ function PieChart(props: PieChartProps) {
         title: {
             text: 'Cumulative Volume (AF) of Rendered Sites'
         },
+        subtitle: {
+            text: `${volumeSum.toFixed(2)} (AF)`
+        },
         tooltip: {
             pointFormat: '<b>{point.percentage:.1f}%</b>'
         },
         series: [
             {
-                data: props.data?.map(x => [x.primaryUseCategoryName, x.points])
+                data: props.dataByBeneficialUse?.map(x => ({ name: x.primaryUseCategoryName, y: x.volume, color: x.color }))
             }
         ]
     };
 
     return <div>
+        <div className="my-3 d-flex justify-content-center">
+            <a href="https://westernstateswater.org/wade/westdaat-analytics" target="_blank" rel="noopener noreferrer">Learn about WestDAAT analytics</a>
+        </div>
         <Row>
-            <Col lg="4"><HighchartsReact highcharts={Highcharts} options={countOptions} />
+            <Col lg="4">
+                <HighchartsReact highcharts={Highcharts} options={countOptions} />
             </Col>
             <Col lg="4">
                 <HighchartsReact highcharts={Highcharts} options={flowOptions} />
             </Col>
-            <Col lg="4"><HighchartsReact highcharts={Highcharts} options={volumeOptions} />
+            <Col lg="4">
+                <HighchartsReact highcharts={Highcharts} options={volumeOptions} />
             </Col>
         </Row>
 

--- a/src/DashboardUI/src/components/TableView.tsx
+++ b/src/DashboardUI/src/components/TableView.tsx
@@ -3,12 +3,13 @@ import { Button, Nav, Offcanvas, ProgressBar, Tab, Table } from "react-bootstrap
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js';
 import "../styles/tableView.scss";
 import Icon from "@mdi/react";
-import { useFindWaterRights } from "../hooks/useWaterRightQuery";
+import { useFindWaterRights, useGetAnalyticsSummaryInfo } from "../hooks/useWaterRightQuery";
 import { WaterRightsSearchCriteria } from "../data-contracts/WaterRightsSearchCriteria";
 import { WaterRightsSearchResults } from "../data-contracts/WaterRightsSearchResults";
 import { FormattedDate } from "./FormattedDate";
 import { FilterContext } from "../FilterProvider";
 import moment from "moment";
+import PieChart from "./PieChart";
 
 interface TableViewProps {
   containerRef: React.MutableRefObject<any>;
@@ -41,7 +42,7 @@ function TableView(props: TableViewProps) {
   const handleFiltersChange = useCallback(() => {
     setWaterRightsSearchResults(_defaultResults);
     setSearchCriteria({
-      pageNumber: 0,      
+      pageNumber: 0,
       beneficialUses: filters.beneficialUses?.map(b => b.beneficialUseName),
       filterGeometry: filters.polyline.map(p => JSON.stringify(p.data.geometry)),
       expemptofVolumeFlowPriority: filters.includeExempt,
@@ -55,7 +56,7 @@ function TableView(props: TableViewProps) {
       ownerClassifications: filters.ownerClassifications,
       waterSourceTypes: filters.waterSourceTypes,
       riverBasinNames: filters.riverBasinNames,
-      allocationOwner: filters.allocationOwner,      
+      allocationOwner: filters.allocationOwner,
       states: filters.states,
     });
   }, [_defaultResults, filters, setSearchCriteria, setWaterRightsSearchResults]);
@@ -66,6 +67,7 @@ function TableView(props: TableViewProps) {
   }
 
   const { data: latestSearchResults, isFetching } = useFindWaterRights(searchCriteria)
+  const { data: pieChartSearchResults } = useGetAnalyticsSummaryInfo(searchCriteria)
 
   useEffect(() => {
     if (show) {
@@ -83,7 +85,7 @@ function TableView(props: TableViewProps) {
       hasMoreResults: latestSearchResults.hasMoreResults,
       waterRightsDetails: [...previousState.waterRightsDetails, ...latestSearchResults.waterRightsDetails]
     }));
-  }, [latestSearchResults]);
+  }, [latestSearchResults, pieChartSearchResults]);
 
   return <>
     <Button type="button" className={`table-view-toggle-btn ${show ? "toggle-on" : null}`} onClick={toggleShow}>
@@ -102,6 +104,9 @@ function TableView(props: TableViewProps) {
           <Nav variant="tabs" defaultActiveKey="dataTable">
             <Nav.Item>
               <Nav.Link eventKey="dataTable">Data Table</Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link eventKey="pieChart">Pie Chart</Nav.Link>
             </Nav.Item>
           </Nav>
           <Tab.Content>
@@ -152,6 +157,9 @@ function TableView(props: TableViewProps) {
                   }
                 </tbody>
               </Table>
+            </Tab.Pane>
+            <Tab.Pane eventKey="pieChart">
+              <PieChart data={pieChartSearchResults}></PieChart>
             </Tab.Pane>
           </Tab.Content>
         </Offcanvas.Body>

--- a/src/DashboardUI/src/components/TableView.tsx
+++ b/src/DashboardUI/src/components/TableView.tsx
@@ -159,7 +159,7 @@ function TableView(props: TableViewProps) {
               </Table>
             </Tab.Pane>
             <Tab.Pane eventKey="pieChart">
-              <PieChart data={pieChartSearchResults}></PieChart>
+              <PieChart dataByBeneficialUse={pieChartSearchResults}></PieChart>
             </Tab.Pane>
           </Tab.Content>
         </Offcanvas.Body>

--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -13,7 +13,7 @@ import { useDebounceCallback } from "@react-hook/debounce";
 import { useMapErrorAlert, useNoMapResults } from "../hooks/useMapAlert";
 import { PriorityDateRange } from "./PriorityDateRange";
 import { useWaterRightsMapPopup } from "../hooks/useWaterRightsMapPopup";
-import { waterRightsProperties, pointSizes, nldi } from "../config/constants";
+import { waterRightsProperties, pointSizes, nldi, colorList } from "../config/constants";
 import { useBeneficialUses, useOwnerClassifications, useStates, useWaterSourceTypes } from "../hooks/useSystemQuery";
 import { defaultPointCircleRadius, defaultPointCircleSortKey, flowPointCircleSortKey, volumePointCircleSortKey } from "../config/maps";
 import useLastKnownValue from "../hooks/useLastKnownValue";
@@ -56,30 +56,6 @@ const mapColorLegendOptions = [
   { value: MapGrouping.OwnerClassification, label: 'Owner Classification' },
   { value: MapGrouping.WaterSourceType, label: 'Water Source Type' }
 ];
-
-const colors = [
-  '#006400',
-  '#9ACD32',
-  '#FF00E6',
-  '#0000FF',
-  '#32CD32',
-  '#FF4500',
-  '#9370DB',
-  '#00FFFF',
-  '#FF69B4',
-  '#800080',
-  '#00BFFF',
-  '#FFD700',
-  '#A52A2A',
-  '#4B0082',
-  '#808080',
-  '#FFA500',
-  '#D2691E',
-  '#FFC0CB',
-  '#F0FFF0',
-  '#F5DEB3',
-  '#FF0000'
-]
 
 const waterRightsPointsLayer = 'waterRightsPoints';
 const waterRightsPolygonsLayer = 'waterRightsPolygons';
@@ -160,13 +136,13 @@ function WaterRightsTab() {
     let colorMapping: { key: string, color: string }[];
     switch (displayOptions.mapGrouping) {
       case MapGrouping.BeneficialUse:
-        colorMapping = allBeneficialUses?.map(a => ({ key: a.beneficialUseName, color: colors[colorIndex++ % colors.length] })) ?? []
+        colorMapping = allBeneficialUses?.map(a => ({ key: a.beneficialUseName, color: colorList[colorIndex++ % colorList.length] })) ?? []
         break;
       case MapGrouping.OwnerClassification:
-        colorMapping = allOwnerClassifications?.map(a => ({ key: a, color: colors[colorIndex++ % colors.length] })) ?? []
+        colorMapping = allOwnerClassifications?.map(a => ({ key: a, color: colorList[colorIndex++ % colorList.length] })) ?? []
         break;
       case MapGrouping.WaterSourceType:
-        colorMapping = allWaterSourceTypes?.map(a => ({ key: a, color: colors[colorIndex++ % colors.length] })) ?? []
+        colorMapping = allWaterSourceTypes?.map(a => ({ key: a, color: colorList[colorIndex++ % colorList.length] })) ?? []
         break;
     }
     return { property: displayOptions.mapGrouping as string, colorMapping }

--- a/src/DashboardUI/src/config/constants.ts
+++ b/src/DashboardUI/src/config/constants.ts
@@ -38,3 +38,27 @@ export enum waterRightsProperties {
   minPriorityDate = 'minPri',
   maxPriorityDate = 'maxPri',
 }
+
+export const colorList = [
+  '#006400',
+  '#9ACD32',
+  '#FF00E6',
+  '#0000FF',
+  '#32CD32',
+  '#FF4500',
+  '#9370DB',
+  '#00FFFF',
+  '#FF69B4',
+  '#800080',
+  '#00BFFF',
+  '#FFD700',
+  '#A52A2A',
+  '#4B0082',
+  '#808080',
+  '#FFA500',
+  '#D2691E',
+  '#FFC0CB',
+  '#F0FFF0',
+  '#F5DEB3',
+  '#FF0000'
+];

--- a/src/DashboardUI/src/data-contracts/AnalyticsSummaryInformation.ts
+++ b/src/DashboardUI/src/data-contracts/AnalyticsSummaryInformation.ts
@@ -1,0 +1,6 @@
+export class AnalyticsSummaryInformation {
+  primaryUseCategoryName?: string;
+  points?: number;
+  flow?: number;
+  volume?: number;
+}

--- a/src/DashboardUI/src/data-contracts/AnalyticsSummaryInformation.ts
+++ b/src/DashboardUI/src/data-contracts/AnalyticsSummaryInformation.ts
@@ -3,4 +3,5 @@ export class AnalyticsSummaryInformation {
   points?: number;
   flow?: number;
   volume?: number;
+  color?: string;
 }

--- a/src/DashboardUI/src/hooks/useWaterRightQuery.ts
+++ b/src/DashboardUI/src/hooks/useWaterRightQuery.ts
@@ -5,6 +5,7 @@ import {
   getWaterRightSourceInfoList,
   getWaterRightSiteLocations,
   findWaterRight,
+  getWaterRightAnalyticsSummaryInfo,
 } from '../accessors/waterAllocationAccessor';
 import { WaterRightsSearchCriteria } from '../data-contracts/WaterRightsSearchCriteria';
 
@@ -14,6 +15,16 @@ export function useWaterRightDetails(allocationUuid: string) {
     async () => await getWaterRightDetails(allocationUuid),
     {
       enabled: !!allocationUuid,
+    }
+  );
+}
+
+export function useGetAnalyticsSummaryInfo(searchCriteria: WaterRightsSearchCriteria | null) {
+  return useQuery(
+    ['waterRight.AnalyticsSummary', searchCriteria],
+    async () => await getWaterRightAnalyticsSummaryInfo(searchCriteria!),
+    {
+      enabled: searchCriteria !== null
     }
   );
 }


### PR DESCRIPTION
Moved color list from filters page to constants so it can be used to calculate correct colors for pie charts.

Pie chart page displays with correct colors based on beneficial use. 
Hovering on a slice shows you the slice name and the percentage taken up by that beneficial use. 