### PR TITLE
Changing overflow response and height for pie chart and data table formatting

### DIFF
--- a/src/DashboardUI/src/components/AnalyticsDataTable.tsx
+++ b/src/DashboardUI/src/components/AnalyticsDataTable.tsx
@@ -61,7 +61,7 @@ function AnalyticsDataTable() {
         }));
     }, [latestSearchResults]);
 
-    return <div className="fixedTableHead">
+    return <div className="scrollable-content">
         <Table>
             <thead>
                 <tr>

--- a/src/DashboardUI/src/components/PieCharts.tsx
+++ b/src/DashboardUI/src/components/PieCharts.tsx
@@ -121,7 +121,7 @@ function PieCharts() {
         ]
     };
 
-    return <div>
+    return <div className="scrollable-content ">
         <div className="my-3 d-flex justify-content-center">
             <a href="https://westernstateswater.org/wade/westdaat-analytics" target="_blank" rel="noopener noreferrer">Learn about WestDAAT analytics</a>
         </div>

--- a/src/DashboardUI/src/styles/tableView.scss
+++ b/src/DashboardUI/src/styles/tableView.scss
@@ -7,7 +7,7 @@
 
   .offcanvas-body {
     padding-right: 0px !important;
-    overflow-y: unset;
+    overflow-y: hidden;
   }
 
   &.offcanvas-bottom {
@@ -37,11 +37,11 @@
   }
 }
 
-.fixedTableHead {
+.scrollable-content {
   overflow-y: auto;
-  height: 400px;
+  height: $offcanvas-vertical-height - 4vh;
 }
-.fixedTableHead thead th {
+.scrollable-content thead th {
   position: sticky;
   top: 0;
 }


### PR DESCRIPTION
Changed height prevents the "load more" button from being covered up by the footer at the bottom of the page