### PR TITLE
changed meta description of site

### DIFF
--- a/src/DashboardUI/public/index.html
+++ b/src/DashboardUI/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Western States Water Data Access and Analysis Tool (WestDAAT)"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192x192.png" />
     <!--


### PR DESCRIPTION
The meta description is what is used for the link preview feature in most messaging apps.
Before: 
![67b1ef6f-00ae-4cfd-9225-8a42c86b087a](https://user-images.githubusercontent.com/25774009/181120240-41ba6138-eeaa-45d0-8a77-cae587e5f0b2.jpg)

