### PR TITLE
Fix NLDI URL too long

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/WesternStatesWater.WestDaat.Tests.AccessorTests.csproj
+++ b/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/WesternStatesWater.WestDaat.Tests.AccessorTests.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.1" />
     <ProjectReference Include="..\WesternStatesWater.WestDaat.Accessors\WesternStatesWater.WestDaat.Accessors.csproj" />
     <ProjectReference Include="..\WesternStatesWater.WestDaat.Tests.Helpers\WesternStatesWater.WestDaat.Tests.Helpers.csproj" />
     <ProjectReference Include="..\WesternStatesWater.WestDaat.Common\WesternStatesWater.WestDaat.Common.csproj" />

--- a/src/API/WesternStatesWater.WestDaat.Tests.ManagerTests/WesternStatesWater.WestDaat.Tests.ManagerTests.csproj
+++ b/src/API/WesternStatesWater.WestDaat.Tests.ManagerTests/WesternStatesWater.WestDaat.Tests.ManagerTests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
@@ -34,7 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <ProjectReference Include="..\WesternStatesWater.WestDaat.Managers\WesternStatesWater.WestDaat.Managers.csproj" />
   </ItemGroup>
 

--- a/src/DashboardUI/src/FilterProvider.tsx
+++ b/src/DashboardUI/src/FilterProvider.tsx
@@ -19,13 +19,14 @@ export interface WaterRightsFilters{
   minPriorityDate: number | undefined,
   maxPriorityDate: number | undefined,
   polyline: { identifier: string, data: GeoJSON.Feature<GeoJSON.Geometry> }[],
-  nldiFilterData: { latitude: number | null, longitude: number | null, directions: Directions, dataPoints: DataPoints } | null,
-  nldiIds?: string[]
+  nldiFilterData: { latitude: number | null, longitude: number | null, directions: Directions, dataPoints: DataPoints } | null
 }
 
 interface FilterContextState {
   filters: WaterRightsFilters;
   setFilters: React.Dispatch<React.SetStateAction<WaterRightsFilters>>;
+  nldiIds: string[];
+  setNldiIds: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const defaultFilters: WaterRightsFilters = {
@@ -44,13 +45,14 @@ const defaultFilters: WaterRightsFilters = {
   minPriorityDate: undefined,
   maxPriorityDate: undefined,
   polyline: [],
-  nldiFilterData: null,
-  nldiIds: undefined
+  nldiFilterData: null
 }
 
 const defaultState: FilterContextState = {
   filters: defaultFilters,
-  setFilters: () => {}
+  setFilters: () => {},
+  nldiIds: [],
+  setNldiIds: () => {},
 }
 
 export const FilterContext = createContext<FilterContextState>(defaultState);
@@ -59,10 +61,13 @@ export const FilterProvider: FC = ({ children }) => {
   const { getUrlParam } = useContext(AppContext);
 
   const [ filters, setFilters ] = useState<WaterRightsFilters>(getUrlParam<WaterRightsFilters>("wr") ?? defaultFilters);
+  const [ nldiIds, setNldiIds ] = useState<string[]>([]);
 
   const filterContextProviderValue = {
     filters,
-    setFilters
+    setFilters,
+    nldiIds,
+    setNldiIds
   }
 
   return (

--- a/src/DashboardUI/src/components/AnalyticsDataTable.tsx
+++ b/src/DashboardUI/src/components/AnalyticsDataTable.tsx
@@ -38,7 +38,11 @@ function AnalyticsDataTable() {
             states: filters.states,
             wadeSitesUuids: nldiIds
         });
-    }, [_defaultResults, filters, nldiIds, setSearchCriteria, setWaterRightsSearchResults]);
+    }, [_defaultResults, filters.allocationOwner, filters.beneficialUses, filters.includeExempt, 
+        filters.maxFlow, filters.maxPriorityDate, filters.maxVolume, filters.minFlow, filters.minPriorityDate, 
+        filters.minVolume, filters.ownerClassifications, filters.podPou, filters.polyline, filters.riverBasinNames, 
+        filters.states, filters.waterSourceTypes, 
+        nldiIds]); //there are properties on the filters object that need to be ignored, so the properties to subscribe to must be explicitly listed
 
     const handleLoadMoreResults = () => {
         if (waterRightsSearchResults.waterRightsDetails.length === 0) return;
@@ -46,9 +50,13 @@ function AnalyticsDataTable() {
     }
 
     const { data: latestSearchResults, isFetching: isFetchingTableData } = useFindWaterRights(searchCriteria)
+
     useEffect(() => {
         handleFiltersChange();
-    }, [filters, handleFiltersChange]);
+    }, [filters.allocationOwner, filters.beneficialUses, filters.includeExempt, filters.maxFlow, filters.maxPriorityDate, 
+        filters.maxVolume, filters.minFlow, filters.minPriorityDate, filters.minVolume, filters.ownerClassifications, 
+        filters.podPou, filters.polyline, filters.riverBasinNames, filters.states, filters.waterSourceTypes, 
+        handleFiltersChange]);
 
     useEffect(() => {
         if (!latestSearchResults) return;

--- a/src/DashboardUI/src/components/AnalyticsDataTable.tsx
+++ b/src/DashboardUI/src/components/AnalyticsDataTable.tsx
@@ -15,7 +15,7 @@ function AnalyticsDataTable() {
     const [searchCriteria, setSearchCriteria] = useState<WaterRightsSearchCriteria | null>(null);
     const [waterRightsSearchResults, setWaterRightsSearchResults] = useState<WaterRightsSearchResults>(_defaultResults);
 
-    const { filters } = useContext(FilterContext);
+    const { filters, nldiIds } = useContext(FilterContext);
 
     const handleFiltersChange = useCallback(() => {
         setWaterRightsSearchResults(_defaultResults);
@@ -36,9 +36,9 @@ function AnalyticsDataTable() {
             riverBasinNames: filters.riverBasinNames,
             allocationOwner: filters.allocationOwner,
             states: filters.states,
-            wadeSitesUuids: filters.nldiIds
+            wadeSitesUuids: nldiIds
         });
-    }, [_defaultResults, filters, setSearchCriteria, setWaterRightsSearchResults]);
+    }, [_defaultResults, filters, nldiIds, setSearchCriteria, setWaterRightsSearchResults]);
 
     const handleLoadMoreResults = () => {
         if (waterRightsSearchResults.waterRightsDetails.length === 0) return;

--- a/src/DashboardUI/src/components/DownloadModal.tsx
+++ b/src/DashboardUI/src/components/DownloadModal.tsx
@@ -59,7 +59,7 @@ function DownloadWaterRights(props: {
 
 function DownloadModal(props: DownloadModalProps) {
   const { isAuthenticated } = useContext(AppContext).authenticationContext;
-  const { filters } = useContext(FilterContext);
+  const { filters, nldiIds } = useContext(FilterContext);
 
   const [ searchCriteria, setSearchCriteria] = useState<WaterRightsSearchCriteria | null>(null);
   const [ isFetching, setIsFetching ] = useState<boolean>(false);
@@ -105,7 +105,7 @@ function DownloadModal(props: DownloadModalProps) {
       allocationOwner: filters.allocationOwner,
       states: filters.states,
       filterUrl: filters !== null ? window.location.href : undefined,
-      wadeSitesUuids: filters.nldiIds
+      wadeSitesUuids: nldiIds
     });
   }
 

--- a/src/DashboardUI/src/components/PieCharts.tsx
+++ b/src/DashboardUI/src/components/PieCharts.tsx
@@ -10,7 +10,7 @@ import { useGetAnalyticsSummaryInfo } from '../hooks';
 import { useBeneficialUses } from '../hooks/useSystemQuery';
 
 function PieCharts() {
-    const { filters } = useContext(FilterContext);
+    const { filters, nldiIds } = useContext(FilterContext);
     const [searchCriteria, setSearchCriteria] = useState<WaterRightsSearchCriteria | null>(null);
 
     const handleFiltersChange = useCallback(() => {
@@ -30,9 +30,9 @@ function PieCharts() {
             riverBasinNames: filters.riverBasinNames,
             allocationOwner: filters.allocationOwner,
             states: filters.states,
-            wadeSitesUuids: filters.nldiIds
+            wadeSitesUuids: nldiIds
         });
-    }, [filters, setSearchCriteria]);
+    }, [filters, nldiIds, setSearchCriteria]);
 
     const { data: pieChartSearchResults, isFetching } = useGetAnalyticsSummaryInfo(searchCriteria)
     useEffect(() => {

--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -298,7 +298,6 @@ function WaterRightsTab() {
     }
   }, [setLegend, renderedMapGroupings, isNldiMapActive])
 
-  //const [mappedSites, setMappedSites] = useState<string[]>([]);
   const [allocationOwnerValue, setAllocationOwnerValue] = useState(filters.allocationOwner ?? "");
   const hasRenderedFeatures = useMemo(() => renderedFeatures.length > 0, [renderedFeatures.length]);
   const nldiWadeSiteIds = useMemo(() => {

--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -302,6 +302,9 @@ function WaterRightsTab() {
   const [allocationOwnerValue, setAllocationOwnerValue] = useState(filters.allocationOwner ?? "");
   const hasRenderedFeatures = useMemo(() => renderedFeatures.length > 0, [renderedFeatures.length]);
   const nldiWadeSiteIds = useMemo(() => {
+    if(!isNldiMapActive){
+      return [];
+    }
     let nldiData = geoJsonData.filter(s => s.source === 'nldi');
     if (nldiData && nldiData.length > 0 && nldiFilterData !== null) {
       let arr = (nldiData[0].data as FeatureCollection).features
@@ -312,22 +315,22 @@ function WaterRightsTab() {
       } else if (!(nldiFilterData?.directions & Directions.Upsteam) && (nldiFilterData?.directions & Directions.Downsteam)) {
         arr = arr.filter(x => x.properties?.westdaat_direction === 'Downstream');
       } else if (!(nldiFilterData?.directions & Directions.Upsteam) && !(nldiFilterData?.directions & Directions.Downsteam)) {
-        //setNldiIds([]);
         return [];
       }
       return arr.filter(x => x.properties?.identifier !== null && x.properties?.identifier !== undefined)
         .map(a => a.properties?.identifier);
-      //setNldiIds(mappedSites);
-
-      //return mappedSites;
     }else{ // if nldi is not active, empty the array
-      //setNldiIds([]);
       return [];
     }
-  }, [geoJsonData, nldiFilterData]);
+  }, [geoJsonData, nldiFilterData, isNldiMapActive]);
 
   useEffect(() => {
-    setNldiIds(nldiWadeSiteIds);
+    setNldiIds(previousState => {
+      if(deepEqual(previousState, nldiWadeSiteIds)){
+        return previousState;
+      }
+      return nldiWadeSiteIds;
+    });
   }, [nldiWadeSiteIds, setNldiIds]);
 
   useEffect(() => {

--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -84,8 +84,7 @@ const defaultFilters: WaterRightsFilters = {
   minPriorityDate: undefined,
   maxPriorityDate: undefined,
   polyline: [],
-  nldiFilterData: null,
-  nldiIds: []
+  nldiFilterData: null
 }
 
 const defaultDisplayOptions: WaterRightsDisplayOptions = {
@@ -124,7 +123,7 @@ function WaterRightsTab() {
   const { data: allStates, isFetching: isAllStatesLoading, isError: isAllStatesError } = useStates();
   const { data: allRiverBasinOptions, isFetching: isRiverBasinOptionsLoading } = useRiverBasinOptions();
   const { setUrlParam, getUrlParam } = useContext(AppContext);
-  const { filters, setFilters } = useContext(FilterContext);
+  const { filters, setFilters, setNldiIds } = useContext(FilterContext);
   const { data: riverBasinPolygons, isFetching: isRiverBasinPolygonsLoading } = useQuery(['riverBasinPolygonsByName', filters.riverBasinNames ?? []], async (): Promise<GeoJSON.FeatureCollection<GeoJSON.Geometry, GeoJSON.GeoJsonProperties> | undefined> => {
     if ((filters?.riverBasinNames?.length ?? 0) === 0) {
       return undefined;
@@ -299,7 +298,8 @@ function WaterRightsTab() {
     }
   }, [setLegend, renderedMapGroupings, isNldiMapActive])
 
-  const [allocationOwnerValue, setAllocationOwnerValue] = useState(filters.allocationOwner ?? "")
+  //const [mappedSites, setMappedSites] = useState<string[]>([]);
+  const [allocationOwnerValue, setAllocationOwnerValue] = useState(filters.allocationOwner ?? "");
   const hasRenderedFeatures = useMemo(() => renderedFeatures.length > 0, [renderedFeatures.length]);
   const nldiWadeSiteIds = useMemo(() => {
     let nldiData = geoJsonData.filter(s => s.source === 'nldi');
@@ -312,26 +312,23 @@ function WaterRightsTab() {
       } else if (!(nldiFilterData?.directions & Directions.Upsteam) && (nldiFilterData?.directions & Directions.Downsteam)) {
         arr = arr.filter(x => x.properties?.westdaat_direction === 'Downstream');
       } else if (!(nldiFilterData?.directions & Directions.Upsteam) && !(nldiFilterData?.directions & Directions.Downsteam)) {
-        setFilters(s => ({
-          ...s,
-          nldiIds: []
-        }));
-        return
+        //setNldiIds([]);
+        return [];
       }
-      let mappedSites = arr.filter(x => x.properties?.identifier !== null && x.properties?.identifier !== undefined)
-        .map(a => a.properties?.identifier)
-        setFilters(s => ({
-          ...s,
-          nldiIds: mappedSites
-        }));
-        return mappedSites;
+      return arr.filter(x => x.properties?.identifier !== null && x.properties?.identifier !== undefined)
+        .map(a => a.properties?.identifier);
+      //setNldiIds(mappedSites);
+
+      //return mappedSites;
     }else{ // if nldi is not active, empty the array
-      setFilters(s => ({
-        ...s,
-        nldiIds: []
-      }));
+      //setNldiIds([]);
+      return [];
     }
-  }, [geoJsonData, nldiFilterData, setFilters])
+  }, [geoJsonData, nldiFilterData]);
+
+  useEffect(() => {
+    setNldiIds(nldiWadeSiteIds);
+  }, [nldiWadeSiteIds, setNldiIds]);
 
   useEffect(() => {
     if (deepEqual(filters, defaultFilters)) {


### PR DESCRIPTION
- Fixed the bug where all WaDE Site UUIDs were being saved to the URL which was making the URL too long for browsers to handle.
- Also fixed a bug where changing the Scope of Query toggles for NLDI would cause the Table Data to show no results.
- Also fixed PR build errors on the back-end build because of duplicate references in the project files

Example of URL with NLDI sites enabled after fix:
https://westdaatqa.westernstateswater.org/?state=N4Ig7gTiBcoA4HsA2BPJBLAdgUxgbQF0AaETJAE3QDF0kAXbCAEQEM6WZQk306BXcrmgAWAAwA6YQE5RUkkgSYA5rwFCAtAEZZ40dICsJShGwBjOukUBnGAGYjbFgAUEWOjeiaAviSvsGHnggAMIA8iAkAKoAKiDEIABG2DgAZuim6CxIkVbYgQQ%2BIAC2LHCcIABeCAhFADLYAG7YSDBS4poAbPoATN0A7NqitlIAHFJ9HfI8-IIwYuK2I33CttqdtvqiHXryiiozGtptmmPd%2Bj2rIxvdhWSU5dwWB3MS0rK7yqqz0Fo6elKGEDGMwWax2BzsFxuDzeEh3dAAQXM6CaMDoED42C8QA

