### PR TITLE
Adds header/footer to detail layout

### DIFF
--- a/src/DashboardUI/.gitignore
+++ b/src/DashboardUI/.gitignore
@@ -12,6 +12,7 @@
 /build
 
 # misc
+.fleet/
 .DS_Store
 .env.development.local
 .env.test.local

--- a/src/DashboardUI/src/components/SiteNavbar.tsx
+++ b/src/DashboardUI/src/components/SiteNavbar.tsx
@@ -16,9 +16,9 @@ import { NavDropdown } from "react-bootstrap";
 import { useAuthenticationContext } from "../hooks/useAuthenticationContext";
 
 interface SiteNavbarProps {
-  currentTab: HomePageTab;
-  onTabClick: (tab: HomePageTab) => void;
-  showDownloadModal(show: boolean): void;
+  currentTab?: HomePageTab;
+  onTabClick?: (tab: HomePageTab) => void;
+  showDownloadModal?: (show: boolean) => void;
 }
 
 function handleLogout(msalContext: IPublicClientApplication | null) {
@@ -29,7 +29,7 @@ function handleLogout(msalContext: IPublicClientApplication | null) {
     });
 }
 
-function SiteNavbar(props: SiteNavbarProps) {
+function SiteNavbar({currentTab, onTabClick, showDownloadModal}: SiteNavbarProps = {}) {
   const { instance: msalContext } = useMsal();
   const { user } = useAuthenticationContext();
   const [showHamburgerMenu, setShowHamburgerMenu] = useState(false);
@@ -76,21 +76,23 @@ function SiteNavbar(props: SiteNavbarProps) {
         </Container>
       </Navbar>
 
-      <Navbar bg="light" className="p-0 second-nav">
-        <Container fluid className="p-0">
-          <Nav>
-            {(Object.values(HomePageTab)).map(tab =>
-              <Nav.Link onClick={() => props.onTabClick(tab)} className={`py-3 px-4 ${props.currentTab === tab ? 'active-tab' : ''}`} key={tab}>
-                {tab}
-              </Nav.Link>
-            )}
-          </Nav>
+      {onTabClick && showDownloadModal && currentTab &&
+        <Navbar bg="light" className="p-0 second-nav">
+          <Container fluid className="p-0">
+            <Nav>
+              {(Object.values(HomePageTab)).map(tab =>
+                <Nav.Link onClick={() => onTabClick(tab)} className={`py-3 px-4 ${currentTab === tab ? 'active-tab' : ''}`} key={tab}>
+                  {tab}
+                </Nav.Link>
+                )}
+            </Nav>
 
-          <div className="mx-2">
-            <Button className="ms-1" onClick={() => props.showDownloadModal(true)}>Download Data</Button>
-          </div>
-        </Container>
-      </Navbar>
+            <div className="mx-2">
+              <Button className="ms-1" onClick={() => showDownloadModal(true)}>Download Data</Button>
+            </div>
+          </Container>
+        </Navbar>
+      }
 
       <Offcanvas show={showHamburgerMenu} onHide={handleClose} className="ham-menu">
         <Offcanvas.Header closeButton>

--- a/src/DashboardUI/src/pages/DetailLayout.tsx
+++ b/src/DashboardUI/src/pages/DetailLayout.tsx
@@ -1,18 +1,33 @@
 import { Outlet } from "react-router-dom";
+import '../styles/detail-layout.scss';
+import SiteFooter from "../components/SiteFooter";
+import {useState} from "react";
+import SiteNavbar from "../components/SiteNavbar";
+import FeedbackModal from "../components/FeedbackModal";
 
 // TODO: Do we need logic to redirect if we don't have detail type or detail id in route?
 
 function DetailLayout() {
+  const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+
+  const shouldShowFeedbackModal = (show: boolean) => {
+    setShowFeedbackModal(show);
+  }
+
   return (
     <>
-      {/* A "layout route" is a good place to put markup you want to
-          share across all the pages on your site, like navigation. */}
+      <div className="detail-layout d-flex flex-column">
+        {/* A "layout route" is a good place to put markup you want to
+            share across all the pages on your site, like navigation. */}
 
-      {/* An <Outlet> renders whatever child route is currently active,
-          so you can think about this <Outlet> as a placeholder for
-          the child routes we defined above. */}
-      <Outlet />
-      
+        {/* An <Outlet> renders whatever child route is currently active,
+            so you can think about this <Outlet> as a placeholder for
+            the child routes we defined above. */}
+        <SiteNavbar />
+        <Outlet />
+        <SiteFooter showFeedbackModal={shouldShowFeedbackModal} />
+      </div>
+      <FeedbackModal show={showFeedbackModal} setShow={shouldShowFeedbackModal} />
     </>
   );
 }

--- a/src/DashboardUI/src/pages/DetailsPage.tsx
+++ b/src/DashboardUI/src/pages/DetailsPage.tsx
@@ -35,7 +35,7 @@ function DetailsPage(props: detailPageProps) {
 
   return (
     <>
-      <div className="detail-page d-flex flex-column">
+      <div className="detail-page d-flex flex-column flex-grow-1">
         <div className='d-flex flex-row align-items-center justify-content-md-between title-header'>
           <div className='p-2'>
             {/* <Button variant="link" size="lg"><ChevronLeft></ChevronLeft> Back to Map</Button> */}

--- a/src/DashboardUI/src/styles/detail-layout.scss
+++ b/src/DashboardUI/src/styles/detail-layout.scss
@@ -1,0 +1,3 @@
+.detail-layout {
+  height: 100%;
+}

--- a/src/DashboardUI/src/styles/detail-page.scss
+++ b/src/DashboardUI/src/styles/detail-page.scss
@@ -2,7 +2,6 @@
 
 .detail-page {
   position: relative;
-  height: 100%;
   background-color: $white;
   overflow-y: auto;
   padding: 15px;


### PR DESCRIPTION
* Adds header/footer to detail layout
* Makes tab bar optional (not used in detail layout)
* Makes main content scrollable between header/footer

Site page:
![site_demo](https://user-images.githubusercontent.com/5394797/224420181-3465faa4-3af7-4686-8182-a5b07f05eb2f.png)

Right page:
![rite_demo](https://user-images.githubusercontent.com/5394797/224420173-4c15d219-8ef3-4c20-b8e8-812c388b1491.png)

Right page scrolled:
![rite_demo_scrolled](https://user-images.githubusercontent.com/5394797/224420178-d48291e8-3f7f-441b-a2d5-b04d064850cf.png)
