### PR TITLE
added geometry fixer to fix combined geometry that overlaps

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Accessors/EntityFramework/AllocationAmountsFact.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/EntityFramework/AllocationAmountsFact.cs
@@ -220,13 +220,44 @@ namespace WesternStatesWater.WestDaat.Accessors.EntityFramework
 
             var geometryCombined = GeometryCombiner.Combine(geometries);
 
+            if (DoesGeometryIntersect(geometries))
+            {
+                geometryCombined = GeometryFixer.Fix(geometryCombined, true);
+            }
+
             predicate = predicate.Or(a => a.AllocationBridgeSitesFact.Any(site =>
             site.Site.Geometry != null && site.Site.Geometry.Intersects(geometryCombined)));
 
             predicate = predicate.Or(a => a.AllocationBridgeSitesFact.Any(site =>
             site.Site.SitePoint != null && site.Site.SitePoint.Intersects(geometryCombined)));
-            
+
             return predicate;
+        }
+
+        private static bool DoesGeometryIntersect(Geometry[] geometries)
+        {
+            if (geometries.Length <= 1)
+            {
+                return false;
+            }
+
+            var intersect = false;
+
+            var i = 0;
+
+            while (!intersect && i < geometries.Length)
+            {
+                var j = i + 1;
+
+                while (!intersect && j < geometries.Length)
+                {
+                    intersect = geometries[i].Intersects(geometries[j]);
+                    j++;
+                }
+                i++;
+            }
+
+            return intersect;
         }
 
         #endregion

--- a/src/API/WesternStatesWater.WestDaat.Utilities/WesternStatesWater.WestDaat.Utilities.csproj
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/WesternStatesWater.WestDaat.Utilities.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.5.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.0.4" />
     <PackageReference Include="SendGrid" Version="9.27.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
https://github.com/WSWCWaterDataExchange/WestDAAT/issues/221

GeometryCombiner might not be working correctly when the geometries overlap or intersect. Need to add GeometryFixer to fix it.
https://nettopologysuite.github.io/NetTopologySuite/api/NetTopologySuite.Geometries.Utilities.GeometryCombiner.html
Under remarks: No validation of the result geometry is performed. (The only case where invalidity is possible is where [IPolygonal](https://nettopologysuite.github.io/NetTopologySuite/api/NetTopologySuite.Geometries.IPolygonal.html) geometries are combined and result in a self-intersection).

GeometryFixer: https://nettopologysuite.github.io/NetTopologySuite/api/NetTopologySuite.Geometries.Utilities.GeometryFixer.html