### PR TITLE
fixed Min/Max flow and volume client contract data type

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/WaterRightsSearchCriteria.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/WaterRightsSearchCriteria.cs
@@ -21,10 +21,10 @@ namespace WesternStatesWater.WestDaat.Contracts.Client
         public string[] States { get; set; }
         public string AllocationOwner { get; set; }
         public bool? ExemptOfVolumeFlowPriority { get; set; }
-        public long? MinimumFlow { get; set; } 
-        public long? MaximumFlow { get; set; }
-        public long? MinimumVolume { get; set; }
-        public long? MaximumVolume { get; set; }
+        public double? MinimumFlow { get; set; } 
+        public double? MaximumFlow { get; set; }
+        public double? MinimumVolume { get; set; }
+        public double? MaximumVolume { get; set; }
         public string PodOrPou { get; set; }
         public DateTime? MinimumPriorityDate { get; set; }
         public DateTime? MaximumPriorityDate { get; set; }


### PR DESCRIPTION
The Common.DataContracts and query are already expecting `double` so just need to change the data type for the Client.Contracts

https://dontpaniclabs.visualstudio.com/Western%20States/_backlogs/backlog/Western%20States%20Team/Stories/?workitem=21066
https://github.com/WSWCWaterDataExchange/WestDAAT/issues/193

![image](https://user-images.githubusercontent.com/6611953/226465358-881ac99a-eaf0-436a-9103-47c8d6428a3e.png)

