### PR TITLE
Ylee/analytics table enhancement

### DIFF
--- a/src/DashboardUI/src/components/PieCharts.tsx
+++ b/src/DashboardUI/src/components/PieCharts.tsx
@@ -1,4 +1,5 @@
 import Highcharts from 'highcharts';
+import HighchartsExporting from 'highcharts/modules/exporting'
 import HighchartsReact from 'highcharts-react-official';
 import moment from 'moment';
 import { useContext, useCallback, useState, useEffect } from 'react';
@@ -8,6 +9,10 @@ import { WaterRightsSearchCriteria } from '../data-contracts/WaterRightsSearchCr
 import { FilterContext } from '../FilterProvider';
 import { useGetAnalyticsSummaryInfo } from '../hooks';
 import { useBeneficialUses } from '../hooks/useSystemQuery';
+
+if (typeof Highcharts === 'object') {
+    HighchartsExporting(Highcharts);
+}
 
 function PieCharts() {
     const { filters, nldiIds } = useContext(FilterContext);
@@ -62,6 +67,18 @@ function PieCharts() {
         }
     });
 
+    const chartExporting = {
+      chartOptions: {
+        plotOptions: {
+          pie: {
+            dataLabels: {
+              enabled: true,
+                  format: '<b>{point.name}</b>:<br>{point.y:,.0f} ({point.percentage:.1f}%)',
+            }
+          }
+        }}
+    };
+
     const flowOptions = {
         chart: {
             type: 'pie',
@@ -79,7 +96,8 @@ function PieCharts() {
             {
                 data: pieChartSearchResults?.map(x => ({ name: x.primaryUseCategoryName, y: x.flow, color: x.color }))
             }
-        ]
+        ],
+        exporting: chartExporting
     };
 
     const countOptions = {
@@ -99,7 +117,8 @@ function PieCharts() {
             {
                 data: pieChartSearchResults?.map(x => ({ name: x.primaryUseCategoryName, y: x.points, color: x.color }))
             }
-        ]
+        ],
+        exporting: chartExporting
     };
 
     const volumeOptions = {
@@ -119,7 +138,8 @@ function PieCharts() {
             {
                 data: pieChartSearchResults?.map(x => ({ name: x.primaryUseCategoryName, y: x.volume, color: x.color }))
             }
-        ]
+        ],
+        exporting: chartExporting
     };
 
     return <div className="scrollable-content ">

--- a/src/DashboardUI/src/styles/custom.scss
+++ b/src/DashboardUI/src/styles/custom.scss
@@ -14,7 +14,7 @@ $min-contrast-ratio: 3.9;
 
 $form-check-min-height: 20px;
 
-$offcanvas-vertical-height: 50vh;
+$offcanvas-vertical-height: 55vh;
 
 // Import Bootstrap and its default variables
 @import "~bootstrap/scss/bootstrap.scss";

--- a/src/DashboardUI/src/styles/custom.scss
+++ b/src/DashboardUI/src/styles/custom.scss
@@ -14,5 +14,7 @@ $min-contrast-ratio: 3.9;
 
 $form-check-min-height: 20px;
 
+$offcanvas-vertical-height: 50vh;
+
 // Import Bootstrap and its default variables
 @import "~bootstrap/scss/bootstrap.scss";


### PR DESCRIPTION
https://dontpaniclabs.visualstudio.com/Western%20States/_workitems/edit/21080/

large screen:
![image](https://user-images.githubusercontent.com/6611953/226732226-2a6fcded-bb70-4ffd-8112-852afeb87a72.png)

smaller screen (I played around shrinking the distance between the pie charts and their title(s) but the margin here affects the pie chart export so I decided to keep the default margin):
![image](https://user-images.githubusercontent.com/6611953/226732291-9432b48d-5fb1-4f52-aad3-f95b73363aa2.png)

sample outputs:

SVG:
![cumulative-volume-af-of](https://user-images.githubusercontent.com/6611953/226732519-078eef74-7d4e-447b-a446-14b627b4c7b5.svg)

PNG:
![cumulative-flow-csf-of-w](https://user-images.githubusercontent.com/6611953/226732522-4b687527-171e-433d-83f4-a7cb488ffc4a.png)

PDF: [count-of-water-rights.pdf](https://github.com/WSWCWaterDataExchange/WestDAAT/files/11033322/count-of-water-rights.pdf)

The "Print chart" selection that opens the printer view will not have the total and percentage in the pie chart. Print example:
[WestDAAT - Water Rights Data.pdf](https://github.com/WSWCWaterDataExchange/WestDAAT/files/11033338/WestDAAT.-.Water.Rights.Data.pdf)
