### PR TITLE
updated mapalert verbiage and load timing

### DIFF
--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -577,7 +577,7 @@ function WaterRightsTab() {
   }, [isAllBeneficialUsesError, isAllWaterSourceTypesError, isAllOwnerClassificationsError, isAllStatesError])
 
   useMapErrorAlert(isError);
-  // added isLoading check, but that ony acocunts for filter queries and not map queries
+  // added isLoading check, but this only accounts for filter queries and not map queries
   useNoMapResults(!hasRenderedFeatures && !isLoading);
 
   if (isLoading) return null;

--- a/src/DashboardUI/src/components/WaterRightsTab.tsx
+++ b/src/DashboardUI/src/components/WaterRightsTab.tsx
@@ -577,7 +577,8 @@ function WaterRightsTab() {
   }, [isAllBeneficialUsesError, isAllWaterSourceTypesError, isAllOwnerClassificationsError, isAllStatesError])
 
   useMapErrorAlert(isError);
-  useNoMapResults(!hasRenderedFeatures);
+  // added isLoading check, but that ony acocunts for filter queries and not map queries
+  useNoMapResults(!hasRenderedFeatures && !isLoading);
 
   if (isLoading) return null;
 

--- a/src/DashboardUI/src/hooks/useMapAlert.tsx
+++ b/src/DashboardUI/src/hooks/useMapAlert.tsx
@@ -51,7 +51,7 @@ export function useNoMapResults(hasNoResults: boolean) {
   const [header, body] = useMemo(() => {
     return [
       <h5 className="card-title">No Matching Results</h5>,
-      <>Sorry, that filter combination has no results in view.<br />Please try different criteria or a different map location.</>
+      <>Sorry, these filter combinations have no water rights in this view or map zoom level.<br />Please try different criteria or a different map area that may have the data you're looking for.</>
     ]
   }, []);
   useMapAlert(hasNoResults, header, body)


### PR DESCRIPTION
https://github.com/WSWCWaterDataExchange/WestDAAT/issues/218 

This fixes the "No results" message when loading filters from our backend (initial load of the page). There's still a latency between the map render and message, but it might be diminishing return to get rid of the latency.

https://user-images.githubusercontent.com/6611953/227068668-558302f9-a6a8-4fdc-bf7f-5af5cece3245.mov

