### PR TITLE
Fixed null NLDI data bug

### DIFF
--- a/src/DashboardUI/.vscode/launch.json
+++ b/src/DashboardUI/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
             "url": "http://localhost:3000",

--- a/src/DashboardUI/src/components/home-page/water-rights-tab/hooks/url-parameters/useFiltersUrlParameters.test.ts
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/hooks/url-parameters/useFiltersUrlParameters.test.ts
@@ -254,6 +254,23 @@ describe('getParameter', () => {
         expect(mockSetIsNldiParameterActive).toBeCalledWith(undefined);
         expect(mockSetParameterWaterRights).not.toBeCalled();
       })
+
+      test.each([
+        [null],
+        [undefined],
+        [{latitude: 40, longitude: -110, directions: Directions.Downsteam, dataPoints: DataPoints.Usgs}]
+      ])('nldiFilterData null migration, %j', (initialNldiFilterData: NldiFilters | null | undefined) =>{
+        mockGetParameterWaterRights.mockReturnValue({...filtersWithUndefinedNldiActive, nldiFilterData: initialNldiFilterData, isNldiFilterActive: true});
+    
+        const {result: {current: {getParameter}}} = renderHook(() => useFiltersUrlParameters());
+    
+        const paramResult = getParameter();
+    
+        expect(paramResult?.nldiFilterData).toBe(initialNldiFilterData || undefined);
+    
+        expect(mockSetIsNldiParameterActive).toBeCalledWith(undefined);
+        expect(mockSetParameterWaterRights).toBeCalledTimes(initialNldiFilterData === null ? 1 : 0);
+      })
   
       test.each([
         [true, true],

--- a/src/DashboardUI/src/components/home-page/water-rights-tab/hooks/url-parameters/useFiltersUrlParameters.ts
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/hooks/url-parameters/useFiltersUrlParameters.ts
@@ -34,17 +34,17 @@ export function useFiltersUrlParameters() {
     setParameterOptionalNldi(slimmedFilters);
   }, [setParameterOptionalNldi]);
 
-  const getParameter = useCallback((): (WaterRightsFilters | undefined) =>{
-    return getParameterOptionalNldi() as (WaterRightsFilters | undefined);
-  }, [getParameterOptionalNldi]);
-
-  useEffect(() =>{
+  const migrateFilterData = useCallback(() => {
     //migrate the old  water rights filter structure to the new structure
     let filters = getParameterOptionalNldi();
+    let hasUpdate = false;
     if(filters){
-      let hasUpdate = false;
       if(filters.isNldiFilterActive === undefined){
         filters = {...filters, isNldiFilterActive: getIsNldiParameterActive() || false};
+        hasUpdate = true;
+      }
+      if(filters.nldiFilterData === null){
+        filters = {...filters, nldiFilterData: undefined};
         hasUpdate = true;
       }
       if(filters.beneficialUses){
@@ -69,12 +69,21 @@ export function useFiltersUrlParameters() {
         }
         hasUpdate = true;
       }
-      if(hasUpdate){
-        setParameter(filters as WaterRightsFilters);
-      }
+    }
+    return [filters, hasUpdate];
+  }, [getIsNldiParameterActive, getParameterOptionalNldi])
+
+  const getParameter = useCallback((): (WaterRightsFilters | undefined) =>{
+    return migrateFilterData()[0] as (WaterRightsFilters | undefined);
+  }, [migrateFilterData]);
+
+  useEffect(() =>{
+    const [filters, hasUpdate] = migrateFilterData();
+    if(hasUpdate){
+      setParameter(filters as WaterRightsFilters);
     }
     setIsNldiParameterActive(undefined)
-  }, [getParameterOptionalNldi, getIsNldiParameterActive, setIsNldiParameterActive, setParameter]);
+  }, [migrateFilterData, setIsNldiParameterActive, setParameter]);
 
   return {getParameter, setParameter}
 }


### PR DESCRIPTION
If the URL had null for the NLDI data, migration was running after the filters were set and causing errors.