### PR TITLE
Emulate API Connector Locally - Set User Context From Database

### DIFF
--- a/infrastructure/azuredeploy.bicep
+++ b/infrastructure/azuredeploy.bicep
@@ -247,6 +247,7 @@ var fnAppSettings = {
   'Database:AccessTokenDatabaseTenantId': subscription().tenantId
   'Database:WadeConnectionString': 'Server=tcp:${wadedbserver},1433;Initial Catalog=${wadedbname};Persist Security Info=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'
   'Database:WestDaatConnectionString': 'Server=tcp:${sql_server.name}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sql_server_database.name};Application Name=${sites_fn_resource.name};Persist Security Info=False;MultipleActiveResultSets=False;Encrypt=True;Column Encryption Setting=enabled;TrustServerCertificate=False;Connection Timeout=30;'
+  'Environment:IsDevelopment': false
   'MessageBus:ServiceBusUrl': '${service_bus.name}.servicebus.windows.net'
   'Nldi:MaxDownstreamDiversionDistance': '500'
   'Nldi:MaxDownstreamMainDistance': '500'

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/Program.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/Program.cs
@@ -45,6 +45,7 @@ var host = new HostBuilder()
         // Config
         services.AddScoped(_ => configuration.GetBlobStorageConfiguration());
         services.AddScoped(_ => configuration.GetDatabaseConfiguration());
+        services.AddScoped(_ => configuration.GetEnvironmentConfiguration());
         services.AddScoped(_ => configuration.GetIdentityProviderConfiguration());
         services.AddScoped(_ => configuration.GetMessageBusConfiguration());
         services.AddScoped(_ => configuration.GetNldiConfiguration());

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/local.settings.json
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/local.settings.json
@@ -21,5 +21,8 @@
     "LogLevel": {
       "Default": "Information"
     }
+  },
+  "Environment": {
+    "IsDevelopment": true
   }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/Configuration/ConfigurationHelper.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/Configuration/ConfigurationHelper.cs
@@ -73,6 +73,11 @@ namespace WesternStatesWater.WestDaat.Common.Configuration
         {
             return config.GetSection(ConfigurationRootNames.Identity).Get<IdentityProviderConfiguration>() ?? new IdentityProviderConfiguration();
         }
+        
+        public static EnvironmentConfiguration GetEnvironmentConfiguration(this IConfiguration config)
+        {
+            return config.GetSection(ConfigurationRootNames.Environment).Get<EnvironmentConfiguration>() ?? new EnvironmentConfiguration();
+        }
 
         public static TokenCredential TokenCredential => new ChainedTokenCredential(
             new AzureCliCredential(), // When Local

--- a/src/API/WesternStatesWater.WestDaat.Common/Configuration/EnvironmentConfiguration.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/Configuration/EnvironmentConfiguration.cs
@@ -1,0 +1,6 @@
+namespace WesternStatesWater.WestDaat.Common.Configuration;
+
+public class EnvironmentConfiguration
+{
+    public bool IsDevelopment { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Tests.Helpers/JwtFaker.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Helpers/JwtFaker.cs
@@ -23,7 +23,7 @@ public static class JwtFaker
             claims.Add(
                 new Claim(
                     "extension_westdaat_organizationRoles",
-                    string.Join(',', orgRoles.Select(orgId =>$"org_{orgId.Key}/rol_{orgId.Value}"))
+                    string.Join(',', orgRoles.Select(orgId => $"org_{orgId.Key}/rol_{orgId.Value}"))
                 )
             );
         }
@@ -37,6 +37,8 @@ public static class JwtFaker
                 )
             );
         }
+
+        claims.Add(new Claim("emails", "wesley@westdaat.com"));
 
         var jwt = new JwtSecurityToken(
             "issuer",

--- a/src/API/WesternStatesWater.WestDaat.Utilities/WesternStatesWater.WestDaat.Utilities.csproj
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/WesternStatesWater.WestDaat.Utilities.csproj
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <ProjectReference Include="..\WesternStatesWater.WestDaat.Contracts.Client\WesternStatesWater.WestDaat.Contracts.Client.csproj" />
+    <ProjectReference Include="..\WesternStatesWater.WestDaat.Database\WesternStatesWater.WestDaat.Database.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\GeoConnexJsonLDResource.Designer.cs">


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?


Since the API Connector from B2C won't work locally, when a user context is built and we're running locally, look up the user via jwt user id and fetch the roles for the user context
