### PR TITLE
Retrieve all organizations (part 2 of 3)

### DIFF
--- a/src/API/WesternStatesWater.Shared/DataContracts/RequestBase.cs
+++ b/src/API/WesternStatesWater.Shared/DataContracts/RequestBase.cs
@@ -1,3 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace WesternStatesWater.Shared.DataContracts;
 
-public abstract class RequestBase;
+[JsonDerivedType(typeof(RequestBase), typeDiscriminator: "base")]
+public abstract class RequestBase
+{
+}

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/FunctionBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/FunctionBase.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker.Http;
 using WesternStatesWater.Shared.DataContracts;
 using WesternStatesWater.Shared.Errors;
-using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace WesternStatesWater.WestDaat.Client.Functions
 {

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/FunctionBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/FunctionBase.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
 using System.Net;
 using System.Text.Json;
 using Azure.Core.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker.Http;
-using Newtonsoft.Json;
 using WesternStatesWater.Shared.DataContracts;
 using WesternStatesWater.Shared.Errors;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace WesternStatesWater.WestDaat.Client.Functions
 {
@@ -142,7 +141,7 @@ namespace WesternStatesWater.WestDaat.Client.Functions
                 requestBody = await streamReader.ReadToEndAsync();
             }
 
-            return JsonConvert.DeserializeObject<T>(requestBody);
+            return JsonSerializer.Deserialize<T>(requestBody);
         }
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/OrganizationFunction.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/OrganizationFunction.cs
@@ -29,7 +29,13 @@ public class OrganizationFunction : FunctionBase
         HttpRequestData req)
     {
         var organizationLoadRequest = await ParseRequestBody<OrganizationLoadRequestBase>(req);
-        var results = await _organizationManager.Load<OrganizationLoadRequestBase, OrganizationLoadResponseBase>(organizationLoadRequest);
-        return await CreateResponse(req, results);
+        var result = organizationLoadRequest switch
+        {
+            OrganizationLoadAllRequest request => await _organizationManager
+                .Load<OrganizationLoadAllRequest, OrganizationLoadAllResponse>(request),
+            _ => throw new NotImplementedException(
+                $"Request type {organizationLoadRequest.GetType()} is not implemented.")
+        };
+        return await CreateResponse(req, result);
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PermissionGetRequestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PermissionGetRequestBase.cs
@@ -4,5 +4,5 @@ namespace WesternStatesWater.WestDaat.Common.DataContracts;
 
 public abstract class PermissionsGetRequestBase
 {
-    public ContextBase Context { get; init; } = null!;
+    required public ContextBase Context { get; init; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/Permissions.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/Permissions.cs
@@ -8,6 +8,8 @@ public static class Permissions
 
     public const string ConservationApplicationStore = "ConservationApplication_Store";
 
+    public const string OrganizationLoadAll = "Organization_Load_All";
+
     public const string UserLoad = "User_Load";
 
     public static string[] AllPermissions()

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Admin/OrganizationLoadAllRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Admin/OrganizationLoadAllRequestValidator.cs
@@ -1,0 +1,10 @@
+using FluentValidation;
+
+namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Admin;
+
+public class OrganizationLoadAllRequestValidator : AbstractValidator<OrganizationLoadAllRequest>
+{
+    public OrganizationLoadAllRequestValidator()
+    {
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Admin/OrganizationLoadRequestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Admin/OrganizationLoadRequestBase.cs
@@ -1,7 +1,9 @@
+using System.Text.Json.Serialization;
 using WesternStatesWater.Shared.DataContracts;
 
 namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Admin;
 
+[JsonDerivedType(typeof(OrganizationLoadAllRequest), typeDiscriminator: nameof(OrganizationLoadAllRequest))]
 public class OrganizationLoadRequestBase : RequestBase
 {
 }

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Admin/OrganizationLoadAllRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Admin/OrganizationLoadAllRequestHandler.cs
@@ -1,0 +1,26 @@
+using WesternStatesWater.Shared.Resolver;
+using WesternStatesWater.WestDaat.Accessors;
+using WesternStatesWater.WestDaat.Contracts.Client.Requests.Admin;
+using WesternStatesWater.WestDaat.Contracts.Client.Responses.Admin;
+using WesternStatesWater.WestDaat.Managers.Mapping;
+using CommonContracts = WesternStatesWater.WestDaat.Common.DataContracts;
+
+namespace WesternStatesWater.WestDaat.Managers.Handlers.Admin;
+
+public class
+    OrganizationLoadAllRequestHandler : IRequestHandler<OrganizationLoadAllRequest, OrganizationLoadAllResponse>
+{
+    public IOrganizationAccessor OrganizationAccessor { get; }
+
+    public OrganizationLoadAllRequestHandler(IOrganizationAccessor organizationAccessor)
+    {
+        OrganizationAccessor = organizationAccessor;
+    }
+
+    public async Task<OrganizationLoadAllResponse> Handle(OrganizationLoadAllRequest request)
+    {
+        var accessorRequest = request.Map<CommonContracts.OrganizationLoadAllRequest>();
+        var accessorResponse = (CommonContracts.OrganizationLoadAllResponse)await OrganizationAccessor.Load(accessorRequest);
+        return accessorResponse.Map<OrganizationLoadAllResponse>();
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Admin/OrganizationLoadAllRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Admin/OrganizationLoadAllRequestHandler.cs
@@ -7,8 +7,7 @@ using CommonContracts = WesternStatesWater.WestDaat.Common.DataContracts;
 
 namespace WesternStatesWater.WestDaat.Managers.Handlers.Admin;
 
-public class
-    OrganizationLoadAllRequestHandler : IRequestHandler<OrganizationLoadAllRequest, OrganizationLoadAllResponse>
+public class OrganizationLoadAllRequestHandler : IRequestHandler<OrganizationLoadAllRequest, OrganizationLoadAllResponse>
 {
     public IOrganizationAccessor OrganizationAccessor { get; }
 

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -33,6 +33,7 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
             CreateMap<CommonContracts.OverlayDigest, ClientContracts.OverlayDigest>();
 
             AddUserMappings();
+            AddOrganizationMappings();
         }
 
         private void AddUserMappings()
@@ -46,20 +47,36 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.Version, opt => opt.MapFrom(_ => azureB2CVersionString))
                 .ForMember(dest => dest.Action, opt => opt.MapFrom(_ => azureB2CContinuanceAction))
                 .ForMember(dest => dest.Extension_WestDaat_UserId, opt => opt.MapFrom(src => src.UserId))
-                .ForMember(dest => dest.Extension_WestDaat_Roles, opt => opt.MapFrom(src => 
+                .ForMember(dest => dest.Extension_WestDaat_Roles, opt => opt.MapFrom(src =>
                         string.Join(',', src.UserRoles.Select(role => $"rol_{role}"))
                     )
                 )
-                .ForMember(dest => dest.Extension_WestDaat_OrganizationRoles, opt => opt.MapFrom(src => 
-                        string.Join(',', src.UserOrganizationRoles.Select(orgRole => $"org_{orgRole.OrganizationId}/rol_{orgRole.Role}"))
+                .ForMember(dest => dest.Extension_WestDaat_OrganizationRoles, opt => opt.MapFrom(src =>
+                        string.Join(',', src.UserOrganizationRoles.Select(orgRole =>
+                            $"org_{orgRole.OrganizationId}/rol_{orgRole.Role}"))
                     )
                 )
                 .ForMember(dest => dest.Error, opt => opt.Ignore());
 
             CreateMap<ClientContracts.Requests.Admin.EnrichJwtRequest, CommonContracts.UserExistsRequest>()
                 .ForMember(dest => dest.ExternalAuthId, opt => opt.MapFrom(src => src.ObjectId));
+
             CreateMap<ClientContracts.Requests.Admin.EnrichJwtRequest, CommonContracts.UserStoreCreateRequest>()
                 .ForMember(dest => dest.ExternalAuthId, opt => opt.MapFrom(src => src.ObjectId));
+        }
+
+        private void AddOrganizationMappings()
+        {
+            CreateMap<ClientContracts.Requests.Admin.OrganizationLoadAllRequest,
+                CommonContracts.OrganizationLoadAllRequest>();
+
+            CreateMap<CommonContracts.OrganizationLoadAllResponse,
+                    ClientContracts.Responses.Admin.OrganizationLoadAllResponse>()
+                .ForMember(dest => dest.Organizations, opt => opt.MapFrom(src => src.Organizations))
+                .ForMember(dest => dest.Error, opt => opt.Ignore());
+
+            CreateMap<CommonContracts.OrganizationListItem,
+                ClientContracts.OrganizationListItem>();
         }
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
@@ -86,6 +86,6 @@ public class OrganizationIntegrationTests : IntegrationTestBase
         response.GetType().Should().Be<OrganizationLoadAllResponse>();
         response.Organizations.Should().BeNull();
         response.Error.Should().NotBeNull();
-        response.Error.LogMessage.Should().Contain("but did not have permission to do so.");
+        response.Error!.LogMessage.Should().Contain("but did not have permission to do so.");
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
@@ -1,19 +1,91 @@
 using Microsoft.Extensions.DependencyInjection;
+using WesternStatesWater.WestDaat.Common;
 using WesternStatesWater.WestDaat.Common.Context;
+using WesternStatesWater.WestDaat.Database.EntityFramework;
+using WesternStatesWater.WestDaat.Tests.Helpers;
+using WesternStatesWater.WestDaat.Contracts.Client.Requests.Admin;
+using WesternStatesWater.WestDaat.Contracts.Client.Responses.Admin;
 
 namespace WesternStatesWater.WestDaat.Tests.IntegrationTests.Admin;
 
 [TestClass]
 public class OrganizationIntegrationTests : IntegrationTestBase
 {
-    private CLI.IOrganizationManager _organizationManager; 
-    
+    private CLI.IOrganizationManager _organizationManager;
+    private WestDaatDatabaseContext _dbContext;
+
     [TestInitialize]
     public void TestInitialize()
     {
         _organizationManager = Services.GetRequiredService<CLI.IOrganizationManager>();
+        _dbContext = Services.GetRequiredService<IWestDaatDatabaseContextFactory>().Create();
     }
 
     [TestMethod]
     public void SmokeTest() => _organizationManager.Should().NotBeNull();
+
+    [TestMethod]
+    public async Task Load_OrganizationLoadAllRequest_GlobalAdminUser_Success()
+    {
+        // Arrange
+        var context = new UserContext()
+        {
+            UserId = Guid.NewGuid(),
+            Roles = [Roles.GlobalAdmin],
+            OrganizationRoles = [],
+            ExternalAuthId = ""
+        };
+        ContextUtilityMock.Setup(mock => mock.GetContext())
+            .Returns(context);
+
+        var organization = new OrganizationFaker().Generate();
+        await _dbContext.Organizations.AddAsync(organization);
+        await _dbContext.SaveChangesAsync();
+
+        // Act 
+        var response = await _organizationManager.Load<OrganizationLoadAllRequest, OrganizationLoadAllResponse>(
+            new OrganizationLoadAllRequest()
+            {
+            });
+
+        // Assert
+        response.GetType().Should().Be<OrganizationLoadAllResponse>();
+        response.Error.Should().BeNull();
+        response.Organizations.Should().HaveCount(1);
+        response.Organizations[0].Name.Should().Be("organization1");
+        response.Organizations[0].UserCount.Should().Be(1);
+        response.Organizations[0].EmailDomain.Should().Be("organization1.com");
+    }
+
+    [DataTestMethod]
+    [DataRow(Roles.Member)]
+    [DataRow(Roles.TechnicalReviewer)]
+    [DataRow(Roles.OrganizationAdmin)]
+    [DataRow("Fake role")]
+    public async Task Load_OrganizationLoadAllRequest_NotGlobalAdminUser_ShouldReturnError(string role)
+    {
+        // Arrange
+        var context = new UserContext()
+        {
+            UserId = Guid.NewGuid(),
+            Roles = [role],
+            OrganizationRoles = [],
+            ExternalAuthId = ""
+        };
+
+        ContextUtilityMock.Setup(mock => mock.GetContext())
+            .Returns(context);
+
+        // Act 
+        var response = await _organizationManager.Load<OrganizationLoadAllRequest, OrganizationLoadAllResponse>(
+            new OrganizationLoadAllRequest()
+            {
+            });
+
+        // Assert
+        response.GetType().Should().Be<OrganizationLoadAllResponse>();
+        response.Organizations.Should().BeNull();
+        response.Error.Should().NotBeNull();
+        response.Error.LogMessage.Should().Contain("but did not have permission to do so.");
+    }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Admin/OrganizationIntegrationTests.cs
@@ -28,15 +28,13 @@ public class OrganizationIntegrationTests : IntegrationTestBase
     public async Task Load_OrganizationLoadAllRequest_GlobalAdminUser_Success()
     {
         // Arrange
-        var context = new UserContext()
+        UseUserContext(new UserContext
         {
             UserId = Guid.NewGuid(),
             Roles = [Roles.GlobalAdmin],
             OrganizationRoles = [],
             ExternalAuthId = ""
-        };
-        ContextUtilityMock.Setup(mock => mock.GetContext())
-            .Returns(context);
+        });
 
         var organization = new OrganizationFaker().Generate();
         await _dbContext.Organizations.AddAsync(organization);
@@ -65,16 +63,13 @@ public class OrganizationIntegrationTests : IntegrationTestBase
     public async Task Load_OrganizationLoadAllRequest_NotGlobalAdminUser_ShouldReturnError(string role)
     {
         // Arrange
-        var context = new UserContext()
+        UseUserContext(new UserContext
         {
             UserId = Guid.NewGuid(),
             Roles = [role],
             OrganizationRoles = [],
             ExternalAuthId = ""
-        };
-
-        ContextUtilityMock.Setup(mock => mock.GetContext())
-            .Returns(context);
+        });
 
         // Act 
         var response = await _organizationManager.Load<OrganizationLoadAllRequest, OrganizationLoadAllResponse>(

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/IntegrationTestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/IntegrationTestBase.cs
@@ -58,8 +58,14 @@ namespace WesternStatesWater.WestDaat.Tests.IntegrationTests
 
         public static Dictionary<string, string> DefaultTestConfiguration => new()
         {
-            { $"{ConfigurationRootNames.Database}:{nameof(DatabaseConfiguration.WadeConnectionString)}", "Server=localhost;Initial Catalog=WaDE2Test;TrustServerCertificate=True;User=sa;Password=DevP@ssw0rd!;Encrypt=False;" },
-            { $"{ConfigurationRootNames.Database}:{nameof(DatabaseConfiguration.WestDaatConnectionString)}", "Server=localhost;Initial Catalog=WestDAATTest;TrustServerCertificate=True;User=sa;Password=DevP@ssw0rd!;Encrypt=False;" },
+            {
+                $"{ConfigurationRootNames.Database}:{nameof(DatabaseConfiguration.WadeConnectionString)}",
+                "Server=localhost;Initial Catalog=WaDE2Test;TrustServerCertificate=True;User=sa;Password=DevP@ssw0rd!;Encrypt=False;"
+            },
+            {
+                $"{ConfigurationRootNames.Database}:{nameof(DatabaseConfiguration.WestDaatConnectionString)}",
+                "Server=localhost;Initial Catalog=WestDAATTest;TrustServerCertificate=True;User=sa;Password=DevP@ssw0rd!;Encrypt=False;"
+            },
         };
 
         private void RegisterConfigurationServices(IServiceCollection serviceCollection)
@@ -159,11 +165,11 @@ namespace WesternStatesWater.WestDaat.Tests.IntegrationTests
                 .Returns(new IdentityProviderContext());
         }
 
-        protected void UseUserContext()
+        protected void UseUserContext(UserContext? context = null)
         {
             ContextUtilityMock
                 .Setup(mock => mock.GetContext())
-                .Returns(new UserContext());
+                .Returns(context ?? new UserContext());
         }
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.ManagerTests/DtoMapperTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.ManagerTests/DtoMapperTests.cs
@@ -6,7 +6,7 @@ namespace WesternStatesWater.WestDaat.Tests.ManagerTests
     public class DtoMapperTests
     {
         [TestMethod]
-        public void DtoMapper_IsDtoMApperConfigValid()
+        public void DtoMapper_IsDtoMapperConfigValid()
         {
             DtoMapper.Configuration.AssertConfigurationIsValid();
         }

--- a/src/API/WesternStatesWater.WestDaat.Utilities/MessageBusUtility.cs
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/MessageBusUtility.cs
@@ -22,7 +22,7 @@ public class MessageBusUtility : IMessageBusUtility, IAsyncDisposable
 
     public async Task SendMessageAsync<T>(string queueOrTopicName, T messageObject) where T : RequestBase
     {
-        var message = JsonSerializer.Serialize<RequestBase>(messageObject);
+        var message = JsonSerializer.Serialize<T>(messageObject);
 
         var sender = GetServiceBusSender(queueOrTopicName);
 


### PR DESCRIPTION
### Description

Continuing to set up API work for retrieving a list of all organizations.
The API work will be wrapped up in the next PR.
- Call chain is now complete from endpoint to accessor
- The accessor is currently returning a hard-coded value - this will be finished in the next PR

**API PR 2/3 (this PR)**
- Added a switch case into (`/organizations/search`) endpoint to be able to pass the specified derived type to the manager
- Added an Organization Load All permission to global admin roles
- Added RBAC validation to enforce permissions
- Added handler for the manager
- Added input validator (no validations to run)
- Added DTO mapper ... mappings
- Added integration tests

**API PR 3/3 (next PR)**
- Adding real accessor logic

### Demo

Postman call w/ GlobalAdmin role:
<img width="1502" alt="Global admin" src="https://github.com/user-attachments/assets/dd358908-37a5-422b-829e-13a4fd22edc7" />


Postman call w/o GlobalAdmin role:
<img width="1500" alt="Not global admin" src="https://github.com/user-attachments/assets/9da78c97-5ca2-4c51-b226-9abced20b04a" />

---

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
