### PR TITLE
Organization Dashboard: UI - Restrict Access to Users (part 5)

### DIFF
--- a/src/DashboardUI/src/App.tsx
+++ b/src/DashboardUI/src/App.tsx
@@ -17,6 +17,7 @@ import { AdminGuard } from './pages/admin/AdminGuard';
 import { AdminLayout } from './pages/admin/AdminLayout';
 import { AdminOrganizationsPage } from './pages/admin/AdminOrganizationsPage';
 import { AdminOrganizationsUsersPage } from './pages/admin/AdminOrganizationUsersPage';
+import { ApplicationGuard } from './pages/application/ApplicationGuard';
 import { ApplicationLayout } from './pages/application/ApplicationLayout';
 import { ApplicationReviewPage } from './pages/application/dashboard/ApplicationReviewPage';
 import { OrganizationDashboardPage } from './pages/application/dashboard/OrganizationDashboardPage';
@@ -96,7 +97,7 @@ function App({ msalInstance }: AppProps) {
                     <Route index element={<AccountInformationPage />} />
                   </Route>
                 </Route>
-                <Route path="application">
+                <Route path="application" element={<ApplicationGuard />}>
                   <Route element={<ApplicationLayout />}>
                     <Route path="dashboard" element={<WaterUserDashboardPage />} />
                     <Route path="organization">

--- a/src/DashboardUI/src/pages/application/ApplicationGuard.tsx
+++ b/src/DashboardUI/src/pages/application/ApplicationGuard.tsx
@@ -1,0 +1,15 @@
+import { Outlet, useNavigate } from 'react-router-dom';
+import { useAppContext } from '../../contexts/AppProvider';
+
+export const ApplicationGuard = () => {
+  const {
+    authenticationContext: { authenticationComplete, isAuthenticated, user },
+  } = useAppContext();
+  const navigate = useNavigate();
+
+  if (authenticationComplete && !isAuthenticated) {
+    navigate('/');
+  }
+
+  return <Outlet />;
+};


### PR DESCRIPTION
## Description

This adds a requirement that a user must be logged in in order to access any of the application pages (`/application/*`).

If the user signs out while on one of these pages, they should be routed back to the home page.

## 📋 Issues / Features Coming Soon

- Statistics cards
  - Don't actually calculate based on the displayed/filtered applications (yet)
  - Cards are always visible (even when an error occurs or page is still loading)


## 🔗 References

- #497
- #504
- #506
- #511

## Demo

https://github.com/user-attachments/assets/6cff02b3-c31b-4fe4-ae0b-33398f3c9a8d

---

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
