### PR TITLE
Organization Dashboard: UI - Filter Based on Application Status Display Text

### DIFF
--- a/src/DashboardUI/src/data-contracts/ConservationApplicationStatus.ts
+++ b/src/DashboardUI/src/data-contracts/ConservationApplicationStatus.ts
@@ -2,18 +2,12 @@ export enum ConservationApplicationStatus {
   Unknown = 0,
   InReview = 1,
   Approved = 2,
-  Rejected = 3
+  Rejected = 3,
 }
 
-export function formatConservationApplicationStatusText(status: ConservationApplicationStatus): string {
-  switch (status) {
-    case ConservationApplicationStatus.InReview:
-      return 'In Review';
-    case ConservationApplicationStatus.Approved:
-      return 'Approved';
-    case ConservationApplicationStatus.Rejected:
-      return 'Rejected';
-    case ConservationApplicationStatus.Unknown:
-      return 'Unknown';
-  }
+export const ConservationApplicationStatusDisplayNames: { [key in ConservationApplicationStatus]: string } = {
+  [ConservationApplicationStatus.Unknown]: 'Unknown',
+  [ConservationApplicationStatus.InReview]: 'In Review',
+  [ConservationApplicationStatus.Approved]: 'Approved',
+  [ConservationApplicationStatus.Rejected]: 'Rejected'
 }

--- a/src/DashboardUI/src/data-contracts/ConservationApplicationStatus.ts
+++ b/src/DashboardUI/src/data-contracts/ConservationApplicationStatus.ts
@@ -9,5 +9,5 @@ export const ConservationApplicationStatusDisplayNames: { [key in ConservationAp
   [ConservationApplicationStatus.Unknown]: 'Unknown',
   [ConservationApplicationStatus.InReview]: 'In Review',
   [ConservationApplicationStatus.Approved]: 'Approved',
-  [ConservationApplicationStatus.Rejected]: 'Rejected'
-}
+  [ConservationApplicationStatus.Rejected]: 'Rejected',
+};

--- a/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
+++ b/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
@@ -2,7 +2,7 @@ import { useMsal } from '@azure/msal-react';
 import { mdiCircleMedium } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { DataGrid, GridColumnHeaderParams, GridRenderCellParams } from '@mui/x-data-grid';
-import { Placeholder } from 'react-bootstrap';
+import Placeholder from 'react-bootstrap/esm/Placeholder';
 import Card from 'react-bootstrap/esm/Card';
 import { useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';

--- a/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
+++ b/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
@@ -1,18 +1,8 @@
 import { useMsal } from '@azure/msal-react';
 import { mdiCircleMedium } from '@mdi/js';
 import { Icon } from '@mdi/react';
-import {
-  DataGrid,
-  GetApplyFilterFn,
-  getGridDefaultColumnTypes,
-  GridColDef,
-  GridColumnHeaderParams,
-  GridFilterItem,
-  gridFilterModelSelector,
-  GridFilterOperator,
-  GridRenderCellParams,
-  GridValidRowModel,
-} from '@mui/x-data-grid';
+import { DataGrid, GridColumnHeaderParams, GridRenderCellParams } from '@mui/x-data-grid';
+import { Placeholder } from 'react-bootstrap';
 import Card from 'react-bootstrap/esm/Card';
 import { useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';
@@ -26,6 +16,7 @@ import {
   ConservationApplicationStatus,
   ConservationApplicationStatusDisplayNames,
 } from '../../../data-contracts/ConservationApplicationStatus';
+import { useOrganizationQuery } from '../../../hooks/queries';
 import { useAuthenticationContext } from '../../../hooks/useAuthenticationContext';
 import { DataGridColumns, DataGridRows } from '../../../typings/TypeSafeDataGrid';
 import { getUserOrganization, hasUserRole } from '../../../utilities/securityHelpers';
@@ -33,10 +24,6 @@ import { formatDateString } from '../../../utilities/valueFormatters';
 import { dataGridDateRangeFilter } from './DataGridDateRangeFilter';
 
 import './organization-dashboard-page.scss';
-import { useOrganizationQuery } from '../../../hooks/queries';
-import { Placeholder } from 'react-bootstrap';
-import { GridApiCommunity } from '@mui/x-data-grid/internals';
-import { RefObject } from 'react';
 
 interface ApplicationDataGridColumns {
   applicant: string;
@@ -176,9 +163,7 @@ export function OrganizationDashboardPage() {
       width: 200,
       renderCell: renderAppStatusCell,
       renderHeader,
-      valueGetter: (status: ConservationApplicationStatus) => {
-        return ConservationApplicationStatusDisplayNames[status];
-      },
+      valueGetter: (status: ConservationApplicationStatus) => ConservationApplicationStatusDisplayNames[status],
     },
   ];
 

--- a/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
+++ b/src/DashboardUI/src/pages/application/dashboard/OrganizationDashboardPage.tsx
@@ -24,7 +24,7 @@ import { ApplicationDashboardListItem } from '../../../data-contracts/Applicatio
 import { formatCompensationRateUnitsText } from '../../../data-contracts/CompensationRateUnits';
 import {
   ConservationApplicationStatus,
-  formatConservationApplicationStatusText,
+  ConservationApplicationStatusDisplayNames,
 } from '../../../data-contracts/ConservationApplicationStatus';
 import { useAuthenticationContext } from '../../../hooks/useAuthenticationContext';
 import { DataGridColumns, DataGridRows } from '../../../typings/TypeSafeDataGrid';
@@ -86,16 +86,16 @@ export function OrganizationDashboardPage() {
     <div className="header-column-text">{params.colDef.headerName}</div>
   );
 
-  const renderAppStatusCell = (params: GridRenderCellParams<any, ConservationApplicationStatus>) => {
+  const renderAppStatusCell = (params: GridRenderCellParams<any, string>) => {
     return (
       <>
         <Icon
           size={1}
           path={mdiCircleMedium}
-          className={getApplicationStatusIconClass(params.value!)}
-          title={formatConservationApplicationStatusText(params.value!)}
+          className={getApplicationStatusIconClass(params.row.applicationStatus)}
+          title={params.value!}
         ></Icon>
-        {formatConservationApplicationStatusText(params.value!)}
+        {params.value!}
       </>
     );
   };
@@ -143,40 +143,6 @@ export function OrganizationDashboardPage() {
     return <h1 className="fs-3 fw-bolder">{titleText}</h1>;
   };
 
-  const defaultDataGridStringColumnFilterOperators = getGridDefaultColumnTypes().string.filterOperators;
-
-  const wrappedAppStatusFilterOperators = defaultDataGridStringColumnFilterOperators?.map(
-    (operator: GridFilterOperator, index) => {
-      // provides the function that will execute the actual filtering logic
-      const updatedApplyFilterFn = (
-        filterItem: GridFilterItem,
-        column: GridColDef<any, ConservationApplicationStatus, any>,
-      ) => {
-        // this is the function that actually evaluates whether the row should be filtered out
-        // ApplyFilterFn = (value: V, row: R, column: GridColDef<R, V, F>, apiRef: RefObject<GridApiCommunity>) => boolean;
-        const innerFilterFn = operator.getApplyFilterFn(filterItem, column);
-
-        // innerFilterFn can be null - if so, return null
-        if (!innerFilterFn) {
-          return null;
-        }
-
-        // we will wrap this function to format the value before passing it to the inner function
-        const wrappedInnerFn = (value: ConservationApplicationStatus, row: any, col: GridColDef, apiRef: any) => {
-          const formattedValue = formatConservationApplicationStatusText(value);
-          return innerFilterFn(formattedValue, row, col, apiRef);
-        };
-
-        return wrappedInnerFn;
-      };
-
-      return {
-        ...operator,
-        getApplyFilterFn: updatedApplyFilterFn,
-      };
-    },
-  );
-
   const columns: DataGridColumns<ApplicationDataGridColumns>[] = [
     { field: 'applicant', headerName: 'Applicant', width: 200, renderHeader },
     {
@@ -210,7 +176,9 @@ export function OrganizationDashboardPage() {
       width: 200,
       renderCell: renderAppStatusCell,
       renderHeader,
-      filterOperators: wrappedAppStatusFilterOperators,
+      valueGetter: (status: ConservationApplicationStatus) => {
+        return ConservationApplicationStatusDisplayNames[status];
+      },
     },
   ];
 


### PR DESCRIPTION
## Description

This updates the filtering on the Applications table in the Organization Dashboard.

- The user should be able to filter applications based on the displayed application status text
- The user should also be able to sort applications based on the display application status text

## 🧪 Testing

### Prerequisites

- Need to have at least three submitted applications
   - minimum one for each status (`Approved`, `In Review`, `Rejected`)
   - you need to be a member of those applications' organizations (or be a Global Admin)

### Testing steps

1. Log into the website
2. Navigate to the Organization Dashboard page (`<base_url>/application/organization/dashboard`)
3. Sort the Application Status column (both ascending and descending order)
4. Open the filter on the Application Status column (can be selected from the ellipses menu on the column header)
5. Enter a criteria - ex: status `contains` the text `re`
   - Result: any applications not in `In Review` or `Rejected` status should not be displayed
6. Sort the Application Status column (both ascending and descending order)
7. Change the criteria from `re` to `a`
   - Result: only applications in `Approved` status should be displayed 
8. Clear out the filter criteria (either by removing the `a` or clicking the "X" button on the filter tool)
9. The original list of apps should all be displayed

## 🎥 Demo

https://github.com/user-attachments/assets/cc4b3069-d3e1-4284-b013-be11c647a1eb

---

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
