### PR TITLE
(3/4) Update EstimateConsumptiveUse call chain to retrieve funding org via water right

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/OrganizationFundingDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/OrganizationFundingDetails.cs
@@ -6,6 +6,8 @@ public class OrganizationFundingDetails
 
     public string OrganizationName { get; set; }
 
+    public RasterTimeSeriesModel OpenEtModel { get; set; }
+
     public string OpenEtModelDisplayName { get; set; }
 
     public DateOnly OpenEtDateRangeStart { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequest.cs
@@ -15,18 +15,6 @@ public class EstimateConsumptiveUseRequest : ApplicationStoreRequestBase
     /// </summary>
     public string[] Polygons { get; set; }
 
-    public RasterTimeSeriesModel Model { get; set; }
-
-    /// <summary>
-    /// The beginning year of the date range. Inclusive.
-    /// </summary>
-    public DateOnly DateRangeStart { get; set; }
-
-    /// <summary>
-    /// The ending year of the date range. Inclusive.
-    /// </summary>
-    public DateOnly DateRangeEnd { get; set; }
-
     public int? CompensationRateDollars { get; set; }
 
     public CompensationRateUnits? Units { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequestValidator.cs
@@ -18,11 +18,6 @@ public class EstimateConsumptiveUseRequestValidator : AbstractValidator<Estimate
             polygonEntryValidator.RuleFor(polygon => polygon).NotEmpty();
         });
 
-        RuleFor(x => x.Model).NotEmpty();
-
-        RuleFor(x => x.DateRangeStart).NotEmpty().LessThanOrEqualTo(x => x.DateRangeEnd);
-        RuleFor(x => x.DateRangeEnd).NotEmpty().GreaterThanOrEqualTo(x => x.DateRangeStart);
-
         // if one property is non-null, then they both must be non-null
         RuleFor(x => x.CompensationRateDollars).NotEmpty().When(x => x.Units.HasValue);
         RuleFor(x => x.Units).NotEmpty().When(x => x.CompensationRateDollars.HasValue);

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseRequestValidator.cs
@@ -6,8 +6,6 @@ public class EstimateConsumptiveUseRequestValidator : AbstractValidator<Estimate
 {
     public EstimateConsumptiveUseRequestValidator()
     {
-        RuleFor(x => x.FundingOrganizationId).NotEmpty();
-
         RuleFor(x => x.WaterConservationApplicationId).NotEmpty();
 
         RuleFor(x => x.WaterRightNativeId).NotEmpty();

--- a/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
@@ -133,15 +133,6 @@ internal class ValidationEngine : IValidationEngine
             return CreateForbiddenError(request, context);
         }
 
-        // user has an in-progress application for the requested water right
-        // BUT user is attempting to request an estimate using an organization that may not control this water right
-        var estimateRequestedOfIncorrectOrganization = inProgressApplicationExistsResponse.FundingOrganizationId.HasValue &&
-                                                       inProgressApplicationExistsResponse.FundingOrganizationId.Value != request.FundingOrganizationId;
-        if (estimateRequestedOfIncorrectOrganization)
-        {
-            return CreateForbiddenError(request, context);
-        }
-
         var polygonGeometries = request.Polygons.Select(GeometryHelpers.GetGeometryByWkt).ToArray();
 
         for (int i = 0; i < polygonGeometries.Length; i++)

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -171,9 +171,6 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                     };
                 });
 
-            CreateMap<CommonContracts.WaterRightFundingOrgDetails, CommonContracts.OrganizationFundingDetailsRequest>()
-                .ForMember(dest => dest.OrganizationId, opt => opt.MapFrom(src => src.FundingOrganizationId));
-
             CreateMap<(
                     ClientContracts.Requests.Conservation.EstimateConsumptiveUseRequest Request,
                     CommonContracts.OrganizationFundingDetails Organization,

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -137,7 +137,13 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.TotalObligationDollars, opt => opt.MapFrom(src => src.EstimatedCompensationDollars))
                 .ForMember(dest => dest.TotalWaterVolumeSavingsAcreFeet, opt => opt.MapFrom(src => src.TotalAverageYearlyConsumptionEtAcreFeet));
 
-            CreateMap<ClientContracts.Requests.Conservation.EstimateConsumptiveUseRequest, CommonContracts.MultiPolygonYearlyEtRequest>();
+            CreateMap<
+                (ClientContracts.Requests.Conservation.EstimateConsumptiveUseRequest Request, CommonContracts.OrganizationFundingDetails Organization),
+                CommonContracts.MultiPolygonYearlyEtRequest>()
+                .ForMember(dest => dest.Polygons, opt => opt.MapFrom(src => src.Request.Polygons))
+                .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Organization.OpenEtModel))
+                .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeStart))
+                .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeEnd));
 
             CreateMap<(ClientContracts.Requests.Conservation.EstimateConsumptiveUseRequest Request, CommonContracts.MultiPolygonYearlyEtResponse EtData),
                     CommonContracts.EstimateConservationPaymentRequest>()
@@ -165,17 +171,21 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                     };
                 });
 
+            CreateMap<CommonContracts.WaterRightFundingOrgDetails, CommonContracts.OrganizationFundingDetailsRequest>()
+                .ForMember(dest => dest.OrganizationId, opt => opt.MapFrom(src => src.FundingOrganizationId));
+
             CreateMap<(
                     ClientContracts.Requests.Conservation.EstimateConsumptiveUseRequest Request,
+                    CommonContracts.OrganizationFundingDetails Organization,
                     CommonContracts.MultiPolygonYearlyEtResponse EtResponse,
                     CommonContracts.EstimateConservationPaymentResponse PaymentResponse
                     ),
                     CommonContracts.ApplicationEstimateStoreRequest
                 >()
                 .ForMember(dest => dest.WaterConservationApplicationId, opt => opt.MapFrom(src => src.Request.WaterConservationApplicationId))
-                .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Request.Model))
-                .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Request.DateRangeStart))
-                .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Request.DateRangeEnd))
+                .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Organization.OpenEtModel))
+                .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeStart))
+                .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeEnd))
                 .ForMember(dest => dest.DesiredCompensationDollars, opt => opt.MapFrom(src => src.Request.CompensationRateDollars.Value))
                 .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.Request.Units.Value))
                 .ForMember(dest => dest.EstimatedCompensationDollars, opt => opt.MapFrom(src => src.PaymentResponse.EstimatedCompensationDollars))

--- a/src/API/WesternStatesWater.WestDaat.Tests.EngineTests/Validation/ValidationEngineTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.EngineTests/Validation/ValidationEngineTests.cs
@@ -57,7 +57,6 @@ public class ValidationEngineTests : EngineTestBase
     [DataRow(true, true, true, false, true, DisplayName = "User requests estimate for their own Application with matching fields")]
     [DataRow(false, false, false, false, false, DisplayName = "User requests estimate for Application that does not exist")]
     [DataRow(true, false, true, false, false, DisplayName = "User requests estimate for a different Application that they own")]
-    [DataRow(true, true, false, false, false, DisplayName = "User requests estimate for their own Application but with an incorrect Funding Organization")]
     [DataRow(true, true, true, true, false, DisplayName = "User requests estimate for their own Application with intersecting polygons")]
     public async Task Validate_ValidateEstimateConsumptiveUseRequest_Success(
         bool applicationExists,

--- a/src/API/WesternStatesWater.WestDaat.Tests.EngineTests/Validation/ValidationEngineTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.EngineTests/Validation/ValidationEngineTests.cs
@@ -94,16 +94,10 @@ public class ValidationEngineTests : EngineTestBase
         string polygonWkt = "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))";
         var request = new Contracts.Client.Requests.Conservation.EstimateConsumptiveUseRequest
         {
-            // relevant properties
             WaterRightNativeId = "xyz",
             WaterConservationApplicationId = applicationIdMatches ? applicationId.Value : Guid.NewGuid(),
             FundingOrganizationId = organizationIdMatches ? organizationId.Value : Guid.NewGuid(),
             Polygons = polygonsIntersect ? [polygonWkt, polygonWkt] : [polygonWkt],
-
-            // extraneous properties
-            DateRangeStart = DateOnly.MinValue,
-            DateRangeEnd = DateOnly.MaxValue,
-            Model = RasterTimeSeriesModel.SSEBop,
         };
         var result = await _validationEngine.Validate(request);
 

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Transactions;
 using WesternStatesWater.Shared.Errors;
+using WesternStatesWater.WaDE.Database.EntityFramework;
 using WesternStatesWater.WestDaat.Common;
 using WesternStatesWater.WestDaat.Common.Context;
 using WesternStatesWater.WestDaat.Common.DataContracts;
@@ -248,172 +250,225 @@ public class ApplicationIntegrationTests : IntegrationTestBase
         bool requestShouldIncludeCompensationInfo
     )
     {
-        // Arrange
-        const int monthsInYear = 12;
-        const int startYear = 2024;
-        const int yearRange = 1;
-
-        var user = new UserFaker().Generate();
-        var organization = new OrganizationFaker()
-            .RuleFor(org => org.OpenEtDateRangeInYears, () => yearRange)
-            .Generate();
-        var application = new WaterConservationApplicationFaker(user, organization).Generate();
-
-        await _dbContext.WaterConservationApplications.AddAsync(application);
-
-        WaterConservationApplicationEstimate estimate = null;
-        if (shouldInitializePreviousEstimate)
+        // perform db setup in custom transaction scope to avoid implicit distributed transactions error
+        using var transactionScope = new TransactionScope(TransactionScopeOption.Suppress, new TransactionOptions
         {
-            estimate = new WaterConservationApplicationEstimateFaker(application).Generate();
-            var estimateLocation = new WaterConservationApplicationEstimateLocationFaker(estimate).Generate();
-            var estimateLocationConsumptiveUses = new WaterConservationApplicationEstimateLocationConsumptiveUseFaker(estimateLocation).Generate(12);
+            IsolationLevel = IsolationLevel.ReadCommitted,
+        }, TransactionScopeAsyncFlowOption.Enabled);
 
-            await _dbContext.WaterConservationApplicationEstimateLocationConsumptiveUses.AddRangeAsync(estimateLocationConsumptiveUses);
-        }
+        var wadeDb = Services.GetRequiredService<IDatabaseContextFactory>().Create();
 
-        await _dbContext.SaveChangesAsync();
-
-        if (shouldInitializePreviousEstimate)
+        try
         {
-            estimate.Id.Should().NotBe(Guid.Empty);
-            var estimateCreated = await _dbContext.WaterConservationApplicationEstimates
-                .AnyAsync(e => e.Id == estimate.Id);
-            estimateCreated.Should().BeTrue();
-        }
+            // Arrange
+            const int monthsInYear = 12;
+            const int startYear = 2024;
+            const int yearRange = 1;
+
+            var user = new UserFaker().Generate();
+            var organization = new OrganizationFaker()
+                .RuleFor(org => org.OpenEtDateRangeInYears, () => yearRange)
+                .Generate();
+            await _dbContext.Users.AddAsync(user);
+            await _dbContext.Organizations.AddAsync(organization);
+            await _dbContext.SaveChangesAsync();
+
+            var waterRight = new AllocationAmountFactFaker()
+                .RuleFor(aaf => aaf.ConservationApplicationFundingOrganizationId, () => organization.Id)
+                .Generate();
+            await wadeDb.AllocationAmountsFact.AddAsync(waterRight);
+            await wadeDb.SaveChangesAsync();
 
 
-        OpenEtSdkMock.Setup(x => x.RasterTimeseriesPolygon(It.IsAny<Common.DataContracts.RasterTimeSeriesPolygonRequest>()))
-            .ReturnsAsync(new Common.DataContracts.RasterTimeSeriesPolygonResponse
+            var application = new WaterConservationApplicationFaker()
+                .RuleFor(a => a.ApplicantUserId, () => user.Id)
+                .RuleFor(a => a.FundingOrganizationId, () => organization.Id)
+                .RuleFor(a => a.WaterRightNativeId, () => waterRight.AllocationUuid)
+                .Generate();
+
+            await _dbContext.WaterConservationApplications.AddAsync(application);
+
+            WaterConservationApplicationEstimate estimate = null;
+            if (shouldInitializePreviousEstimate)
             {
-                Data = Enumerable.Range(0, yearRange).Select(yearOffset =>
-                {
-                    var time = DateOnly.FromDateTime(new DateTime(startYear + yearOffset, 1, 1));
-                    return Enumerable.Range(0, monthsInYear).Select(_ => new Common.DataContracts.RasterTimeSeriesPolygonResponseDatapoint
-                    {
-                        Time = time,
-                        Evapotranspiration = 5, // 5in/month = 60in/year = 5ft/year
-                    });
-                })
-                .SelectMany(monthlyData => monthlyData)
-                .ToArray()
-            });
+                estimate = new WaterConservationApplicationEstimateFaker(application).Generate();
+                var estimateLocation = new WaterConservationApplicationEstimateLocationFaker(estimate).Generate();
+                var estimateLocationConsumptiveUses = new WaterConservationApplicationEstimateLocationConsumptiveUseFaker(estimateLocation).Generate(12);
 
+                await _dbContext.WaterConservationApplicationEstimateLocationConsumptiveUses.AddRangeAsync(estimateLocationConsumptiveUses);
+            }
 
-        UseUserContext(new UserContext
-        {
-            UserId = user.Id,
-            Roles = [Roles.GlobalAdmin],
-            OrganizationRoles = [],
-            ExternalAuthId = ""
-        });
-
-        var requestedCompensationPerAcreFoot = 1000;
-        var request = new EstimateConsumptiveUseRequest
-        {
-            FundingOrganizationId = organization.Id,
-            WaterConservationApplicationId = application.Id,
-            WaterRightNativeId = application.WaterRightNativeId,
-            Polygons = [memorialStadiumFootballField],
-        };
-
-        if (requestShouldIncludeCompensationInfo)
-        {
-            request.CompensationRateDollars = requestedCompensationPerAcreFoot;
-            request.Units = Common.DataContracts.CompensationRateUnits.AcreFeet;
-        }
-
-
-        // Act
-        var response = await _applicationManager.Store<
-            EstimateConsumptiveUseRequest,
-            EstimateConsumptiveUseResponse>(
-            request);
-
-
-        // Assert
-        response.Should().NotBeNull();
-        response.Error.Should().BeNull();
-
-
-        // verify response calculations are correct
-        const int knownAvgYearlyEtInches = 60;
-        var knownAvgYearlyEtFeet = knownAvgYearlyEtInches / 12;
-        var expectedAvgYearlyEtAcreFeet = knownAvgYearlyEtFeet * memorialStadiumApproximateAreaInAcres;
-        response.TotalAverageYearlyEtAcreFeet.Should().BeApproximately(expectedAvgYearlyEtAcreFeet, 0.01);
-
-        if (requestShouldIncludeCompensationInfo)
-        {
-            var expectedConservationPayment = requestedCompensationPerAcreFoot * response.TotalAverageYearlyEtAcreFeet;
-            response.ConservationPayment.Should().NotBeNull();
-            response.ConservationPayment.Should().Be((int)expectedConservationPayment);
-        }
-        else
-        {
-            response.ConservationPayment.Should().BeNull();
-        }
-
-        // verify db entries were either created, created and overwritten, or not created at all
-        var dbEstimate = await _dbContext.WaterConservationApplicationEstimates
-            .Include(estimate => estimate.Locations)
-            .ThenInclude(location => location.ConsumptiveUses)
-            .SingleOrDefaultAsync(estimate => estimate.WaterConservationApplicationId == application.Id);
-        var dbEstimateLocation = dbEstimate?.Locations.First();
-        var dbEstimateLocationConsumptiveUses = dbEstimateLocation?.ConsumptiveUses;
-
-        if (requestShouldIncludeCompensationInfo)
-        {
-            // verify db entries were created successfully
-            dbEstimate.Should().NotBeNull();
-            dbEstimate.Locations.Should().HaveCount(1); // 1 polygon
-            dbEstimate.Locations.First().ConsumptiveUses.Should().HaveCount(yearRange); // monthly datapoints are grouped by year
-
-            // verify db fields all match expectations
-            dbEstimate.WaterConservationApplicationId.Should().Be(application.Id);
-            dbEstimate.Model.Should().Be(organization.OpenEtModel);
-            dbEstimate.DateRangeStart.Should().Be(
-                DateOnly.FromDateTime(
-                    new DateTimeOffset(DateTimeOffset.UtcNow.Year - yearRange, 1, 1, 0, 0, 0, TimeSpan.Zero)
-                    .UtcDateTime
-                )
-            );
-            dbEstimate.DateRangeEnd.Should().Be(
-                DateOnly.FromDateTime(
-                    new DateTimeOffset(DateTimeOffset.UtcNow.Year, 1, 1, 0, 0, 0, TimeSpan.Zero)
-                    .AddMinutes(-1)
-                    .UtcDateTime
-                )
-            );
-            dbEstimate.CompensationRateDollars.Should().Be(request.CompensationRateDollars);
-            dbEstimate.CompensationRateUnits.Should().Be(request.Units.Value);
-            dbEstimate.EstimatedCompensationDollars.Should().Be(response.ConservationPayment.Value);
-            dbEstimate.TotalAverageYearlyConsumptionEtAcreFeet.Should().BeApproximately(expectedAvgYearlyEtAcreFeet, 0.01);
-
-            dbEstimateLocation.PolygonWkt.Should().Be(request.Polygons[0]);
-            dbEstimateLocation.PolygonAreaInAcres.Should().BeApproximately(memorialStadiumApproximateAreaInAcres, 0.01);
-
-            dbEstimateLocationConsumptiveUses.All(consumptiveUse =>
-            {
-                var yearMatches = consumptiveUse.Year >= startYear && consumptiveUse.Year < startYear + yearRange;
-                return yearMatches;
-            }).Should().BeTrue();
-            dbEstimateLocationConsumptiveUses.Select(cu => cu.EtInInches).Sum().Should().Be(knownAvgYearlyEtInches);
+            await _dbContext.SaveChangesAsync();
 
             if (shouldInitializePreviousEstimate)
             {
-                // verify db entries were overwritten successfully
-                dbEstimate.Id.Should().NotBe(estimate.Id);
+                estimate.Id.Should().NotBe(Guid.Empty);
+                var estimateCreated = await _dbContext.WaterConservationApplicationEstimates
+                    .AnyAsync(e => e.Id == estimate.Id);
+                estimateCreated.Should().BeTrue();
+            }
 
-                dbEstimateLocation.Id.Should().NotBe(estimate.Locations.First().Id);
 
-                var previousConsumptiveUsesIds = estimate.Locations.First().ConsumptiveUses.Select(cu => cu.Id).ToHashSet();
-                dbEstimateLocationConsumptiveUses.All(cu => previousConsumptiveUsesIds.Contains(cu.Id))
-                    .Should().BeFalse();
+            OpenEtSdkMock.Setup(x => x.RasterTimeseriesPolygon(It.IsAny<Common.DataContracts.RasterTimeSeriesPolygonRequest>()))
+                .ReturnsAsync(new Common.DataContracts.RasterTimeSeriesPolygonResponse
+                {
+                    Data = Enumerable.Range(0, yearRange).Select(yearOffset =>
+                    {
+                        var time = DateOnly.FromDateTime(new DateTime(startYear + yearOffset, 1, 1));
+                        return Enumerable.Range(0, monthsInYear).Select(_ => new Common.DataContracts.RasterTimeSeriesPolygonResponseDatapoint
+                        {
+                            Time = time,
+                            Evapotranspiration = 5, // 5in/month = 60in/year = 5ft/year
+                        });
+                    })
+                    .SelectMany(monthlyData => monthlyData)
+                    .ToArray()
+                });
+
+
+            UseUserContext(new UserContext
+            {
+                UserId = user.Id,
+                Roles = [Roles.GlobalAdmin],
+                OrganizationRoles = [],
+                ExternalAuthId = ""
+            });
+
+            var requestedCompensationPerAcreFoot = 1000;
+            var request = new EstimateConsumptiveUseRequest
+            {
+                FundingOrganizationId = organization.Id,
+                WaterConservationApplicationId = application.Id,
+                WaterRightNativeId = application.WaterRightNativeId,
+                Polygons = [memorialStadiumFootballField],
+            };
+
+            if (requestShouldIncludeCompensationInfo)
+            {
+                request.CompensationRateDollars = requestedCompensationPerAcreFoot;
+                request.Units = Common.DataContracts.CompensationRateUnits.AcreFeet;
+            }
+
+
+            // Act
+            var response = await _applicationManager.Store<
+                EstimateConsumptiveUseRequest,
+                EstimateConsumptiveUseResponse>(
+                request);
+
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Error.Should().BeNull();
+
+
+            // verify response calculations are correct
+            const int knownAvgYearlyEtInches = 60;
+            var knownAvgYearlyEtFeet = knownAvgYearlyEtInches / 12;
+            var expectedAvgYearlyEtAcreFeet = knownAvgYearlyEtFeet * memorialStadiumApproximateAreaInAcres;
+            response.TotalAverageYearlyEtAcreFeet.Should().BeApproximately(expectedAvgYearlyEtAcreFeet, 0.01);
+
+            if (requestShouldIncludeCompensationInfo)
+            {
+                var expectedConservationPayment = requestedCompensationPerAcreFoot * response.TotalAverageYearlyEtAcreFeet;
+                response.ConservationPayment.Should().NotBeNull();
+                response.ConservationPayment.Should().Be((int)expectedConservationPayment);
+            }
+            else
+            {
+                response.ConservationPayment.Should().BeNull();
+            }
+
+            // verify db entries were either created, created and overwritten, or not created at all
+            var dbEstimate = await _dbContext.WaterConservationApplicationEstimates
+                .Include(estimate => estimate.Locations)
+                .ThenInclude(location => location.ConsumptiveUses)
+                .SingleOrDefaultAsync(estimate => estimate.WaterConservationApplicationId == application.Id);
+            var dbEstimateLocation = dbEstimate?.Locations.First();
+            var dbEstimateLocationConsumptiveUses = dbEstimateLocation?.ConsumptiveUses;
+
+            if (requestShouldIncludeCompensationInfo)
+            {
+                // verify db entries were created successfully
+                dbEstimate.Should().NotBeNull();
+                dbEstimate.Locations.Should().HaveCount(1); // 1 polygon
+                dbEstimate.Locations.First().ConsumptiveUses.Should().HaveCount(yearRange); // monthly datapoints are grouped by year
+
+                // verify db fields all match expectations
+                dbEstimate.WaterConservationApplicationId.Should().Be(application.Id);
+                dbEstimate.Model.Should().Be(organization.OpenEtModel);
+                dbEstimate.DateRangeStart.Should().Be(
+                    DateOnly.FromDateTime(
+                        new DateTimeOffset(DateTimeOffset.UtcNow.Year - yearRange, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                        .UtcDateTime
+                    )
+                );
+                dbEstimate.DateRangeEnd.Should().Be(
+                    DateOnly.FromDateTime(
+                        new DateTimeOffset(DateTimeOffset.UtcNow.Year, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                        .AddMinutes(-1)
+                        .UtcDateTime
+                    )
+                );
+                dbEstimate.CompensationRateDollars.Should().Be(request.CompensationRateDollars);
+                dbEstimate.CompensationRateUnits.Should().Be(request.Units.Value);
+                dbEstimate.EstimatedCompensationDollars.Should().Be(response.ConservationPayment.Value);
+                dbEstimate.TotalAverageYearlyConsumptionEtAcreFeet.Should().BeApproximately(expectedAvgYearlyEtAcreFeet, 0.01);
+
+                dbEstimateLocation.PolygonWkt.Should().Be(request.Polygons[0]);
+                dbEstimateLocation.PolygonAreaInAcres.Should().BeApproximately(memorialStadiumApproximateAreaInAcres, 0.01);
+
+                dbEstimateLocationConsumptiveUses.All(consumptiveUse =>
+                {
+                    var yearMatches = consumptiveUse.Year >= startYear && consumptiveUse.Year < startYear + yearRange;
+                    return yearMatches;
+                }).Should().BeTrue();
+                dbEstimateLocationConsumptiveUses.Select(cu => cu.EtInInches).Sum().Should().Be(knownAvgYearlyEtInches);
+
+                if (shouldInitializePreviousEstimate)
+                {
+                    // verify db entries were overwritten successfully
+                    dbEstimate.Id.Should().NotBe(estimate.Id);
+
+                    dbEstimateLocation.Id.Should().NotBe(estimate.Locations.First().Id);
+
+                    var previousConsumptiveUsesIds = estimate.Locations.First().ConsumptiveUses.Select(cu => cu.Id).ToHashSet();
+                    dbEstimateLocationConsumptiveUses.All(cu => previousConsumptiveUsesIds.Contains(cu.Id))
+                        .Should().BeFalse();
+                }
+            }
+            else
+            {
+                // verify db entries were not created
+                dbEstimate.Should().BeNull();
             }
         }
-        else
+        finally
         {
-            // verify db entries were not created
-            dbEstimate.Should().BeNull();
+            // cleanup
+            // necessary since we're using a custom transaction scope
+            wadeDb.AllocationAmountsFact.RemoveRange(wadeDb.AllocationAmountsFact);
+            wadeDb.OrganizationsDim.RemoveRange(wadeDb.OrganizationsDim);
+            wadeDb.DateDim.RemoveRange(wadeDb.DateDim);
+            wadeDb.MethodsDim.RemoveRange(wadeDb.MethodsDim);
+            wadeDb.MethodType.RemoveRange(wadeDb.MethodType);
+            wadeDb.ApplicableResourceType.RemoveRange(wadeDb.ApplicableResourceType);
+            wadeDb.VariablesDim.RemoveRange(wadeDb.VariablesDim);
+            wadeDb.VariableSpecific.RemoveRange(wadeDb.VariableSpecific);
+            wadeDb.Variable.RemoveRange(wadeDb.Variable);
+            wadeDb.AggregationStatistic.RemoveRange(wadeDb.AggregationStatistic);
+            wadeDb.Units.RemoveRange(wadeDb.Units);
+            wadeDb.ReportYearType.RemoveRange(wadeDb.ReportYearType);
+            await wadeDb.SaveChangesAsync();
+
+            _dbContext.WaterConservationApplicationEstimateLocationConsumptiveUses.RemoveRange(_dbContext.WaterConservationApplicationEstimateLocationConsumptiveUses);
+            _dbContext.WaterConservationApplicationEstimateLocations.RemoveRange(_dbContext.WaterConservationApplicationEstimateLocations);
+            _dbContext.WaterConservationApplicationEstimates.RemoveRange(_dbContext.WaterConservationApplicationEstimates);
+            _dbContext.WaterConservationApplications.RemoveRange(_dbContext.WaterConservationApplications);
+            _dbContext.UserProfiles.RemoveRange(_dbContext.UserProfiles);
+            _dbContext.Users.RemoveRange(_dbContext.Users);
+            _dbContext.Organizations.RemoveRange(_dbContext.Organizations);
+            await _dbContext.SaveChangesAsync();
         }
     }
 

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -337,7 +337,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             var requestedCompensationPerAcreFoot = 1000;
             var request = new EstimateConsumptiveUseRequest
             {
-                FundingOrganizationId = organization.Id,
+                FundingOrganizationId = Guid.Empty, // not trusting the frontend to provide this field
                 WaterConservationApplicationId = application.Id,
                 WaterRightNativeId = application.WaterRightNativeId,
                 Polygons = [memorialStadiumFootballField],


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the ECU call chain to retrieve the funding org via the water right.

Important note: technically the `EstimateConsumptiveUseRequest` contract inherits the `FundingOrganizationId` field from the RequestBase contract, but we've opted to not use it here as we don't want to trust the frontend to deliver this field.

## Appearance
Postman success. Notice that the request now no longer includes model and date range fields.
![image](https://github.com/user-attachments/assets/1aeca45d-3f48-4a44-b577-b0aaf2951feb)
