### PR TITLE
MapboxTilesetCreate Reworked Pulling Time Series Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@
 
 1. Run MapboxTilesetCreate console app located in /tools
 2. Optional - Add personal.settings.json for connection string settings
-3. Allocations.Points.geojson and Allocations.Polygons.geojson files will be generated in geojson dir
-4. Run `tippecanoe -zg -o waterRights.mbtiles --read-parallel --drop-densest-as-needed --extend-zooms-if-still-dropping --generate-ids --force -L points:"Allocations.Points.geojson" -L polygons:"Allocations.Polygons.geojson" -L polygons:"Overlays.Polygons.geojson"` This will take about 5 minutes
-5. Upload to mapbox studio
+3. Allocations.Points.geojson and Allocations.Polygons.geojson, Overlays.Polygons.geojson, and TimeSeries.Points.geojson files will be generated in geojson dir
+4. Run `tippecanoe -zg -o waterRights.mbtiles --read-parallel --drop-densest-as-needed --extend-zooms-if-still-dropping --generate-ids --force -L points:"Allocations.Points.geojson" -L polygons:"Allocations.Polygons.geojson"` to generate Water Right Map Tiles. This will take about 5 minutes
+5. Run `tippecanoe -zg -o overlays.mbtiles --read-parallel --drop-densest-as-needed --extend-zooms-if-still-dropping --generate-ids --force -L polygons:"Overlays.Polygons.geojson"` to generate Overlay Map Tiles. This will take about 5 minutes
+6. Run `tippecanoe -zg -o timeSeries.mbtiles --read-parallel --drop-densest-as-needed --extend-zooms-if-still-dropping --generate-ids --force -L points:"TimeSeries.Points.geojson"` to generate Time Series Map Tiles. This will take about 5 minutes
+7. Upload to mapbox studio
 
 
 ## Deployment

--- a/src/API/WesternStatesWater.WestDaat.Tests.MapboxTilesetCreateTests/MapboxTilesetTestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.MapboxTilesetCreateTests/MapboxTilesetTestBase.cs
@@ -82,3 +82,15 @@ public class OverlayFeatureProperties
     public string uuid { get; set; } = null!;
     public string[] oType { get; set; } = null!;
 }
+
+public class TimeSeriesFeatureProperties
+{
+    public string uuid { get; set; } = null!;
+    public string state { get; set; } = null!;
+    public string siteType { get; set; } = null!;
+    public long startDate { get; set; }
+    public long endDate { get; set; }
+    public string[] primaryUseCategory { get; set; } = null!;
+    public string[] variableType { get; set; } = null!;
+    public string[] waterSourceType { get; set; } = null!;
+}

--- a/src/API/WesternStatesWater.WestDaat.Tests.MapboxTilesetCreateTests/TimeSeriesTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.MapboxTilesetCreateTests/TimeSeriesTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using FluentAssertions;
+using WesternStatesWater.WestDaat.Tests.Helpers;
+using WesternStatesWater.WestDaat.Tests.Helpers.Geometry;
+using WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate;
+
+namespace WesternStatesWater.WestDaat.Tests.MapboxTilesetCreateTests;
+
+[TestClass]
+public class TimeSeriesTests : MapboxTilesetTestBase
+{
+    [TestMethod]
+    public async Task CreateTimeSeries()
+    {
+        var dates = new DateDimFaker().Generate(10);
+        Db.DateDim.AddRange(dates);
+        await Db.SaveChangesAsync();
+
+        var sites = new SitesDimFaker()
+            .RuleFor(r => r.SitePoint, new PointFaker().Generate())
+            .RuleFor(r => r.Geometry, new PointFaker().Generate())
+            .Generate(3);
+        Db.SitesDim.AddRange(sites);
+        await Db.SaveChangesAsync();
+        
+        var site1TimeSeries = new SiteVariableAmountsFactFaker()
+            .RuleFor(r => r.SiteId, sites[0].SiteId)
+            .RuleFor(r => r.Site, sites[0])
+            .RuleFor(r => r.TimeframeStartID, f => f.PickRandom(dates.Select(x => x.DateId).Take(5)))
+            .RuleFor(r => r.TimeframeEndID, f => f.PickRandom(dates.Select(x => x.DateId).Skip(5)))
+            .RuleFor(r => r.DataPublicationDateID, dates[4].DateId)
+            .Generate(3);
+        Db.SiteVariableAmountsFact.AddRange(site1TimeSeries);
+        await Db.SaveChangesAsync();
+        
+        var site2TimeSeries = new SiteVariableAmountsFactFaker()
+            .RuleFor(r => r.SiteId, sites[1].SiteId)
+            .RuleFor(r => r.Site, sites[1])
+            .RuleFor(r => r.TimeframeStartID, f => f.PickRandom(dates.Select(x => x.DateId).Take(5)))
+            .RuleFor(r => r.TimeframeEndID, f => f.PickRandom(dates.Select(x => x.DateId).Skip(5)))
+            .RuleFor(r => r.DataPublicationDateID, dates[4].DateId)
+            .Generate(2);
+        Db.SiteVariableAmountsFact.AddRange(site2TimeSeries);
+        await Db.SaveChangesAsync();
+        
+        var site3TimeSeries = new SiteVariableAmountsFactFaker()
+            .RuleFor(r => r.SiteId, sites[2].SiteId)
+            .RuleFor(r => r.Site, sites[2])
+            .RuleFor(r => r.TimeframeStartID, f => f.PickRandom(dates.Select(x => x.DateId).Take(5)))
+            .RuleFor(r => r.TimeframeEndID, f => f.PickRandom(dates.Select(x => x.DateId).Skip(5)))
+            .RuleFor(r => r.DataPublicationDateID, dates[4].DateId)
+            .Generate(1);
+        Db.SiteVariableAmountsFact.AddRange(site3TimeSeries);
+        await Db.SaveChangesAsync();
+        
+        // Act
+        await MapboxTileset.CreateTimeSeries(Db, GeoJsonDir);
+        
+        // Assert
+        var json = await File.ReadAllTextAsync(Path.Combine("geojson", "TimeSeries.Points.geojson"));
+        var features = JsonSerializer.Deserialize<List<Maptiler<TimeSeriesFeatureProperties>>>(json);
+
+        features.Should().NotBeNullOrEmpty();
+        features.Should().HaveCount(3);
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/MapboxTileset.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/MapboxTileset.cs
@@ -454,8 +454,8 @@ public static class MapboxTileset
             { "uuid", siteTimeSeries.First().SiteUuid },
             { "state", siteTimeSeries.First().State },
             { "siteType", siteTimeSeries.First().SiteType },
-            { "startDate", GetUnixTime(siteTimeSeries.Min(x => x.StartDate)) },
-            { "endDate", GetUnixTime(siteTimeSeries.Max(x => x.EndDate)) },
+            { "startDate", GetUnixTime(siteTimeSeries.Min(x => x.StartDate))! },
+            { "endDate", GetUnixTime(siteTimeSeries.Max(x => x.EndDate))! },
             { "primaryUseCategory", siteTimeSeries.Select(x => x.PrimaryUseCagtegory).Distinct().ToArray() },
             { "variableType", siteTimeSeries.Select(x => x.VariableType).Distinct().ToArray() },
             { "waterSourceType", siteTimeSeries.Select(x => x.WaterSourceType).Distinct().ToArray() }

--- a/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/Program.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -51,6 +52,7 @@ namespace WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate
 
             var dbFactory = services.Services.GetRequiredService<IDatabaseContextFactory>();
             var db = dbFactory.Create();
+            db.Database.SetCommandTimeout(int.MaxValue);
             await MapboxTileset.CreateTilesetFiles(db);
         }
     }

--- a/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/TimeSeries.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/TimeSeries.cs
@@ -1,0 +1,18 @@
+using NetTopologySuite.Geometries;
+
+namespace WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate;
+
+public class TimeSeries
+{
+    public long SiteId { get; set; }
+    public long SiteVariableAmountId { get; set; }
+    public string SiteUuid { get; set; }
+    public string State { get; set; }
+    public string SiteType { get; set; }
+    public Geometry Location { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public string PrimaryUseCagtegory { get; set; }
+    public string VariableType { get; set; }
+    public string WaterSourceType { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/TimeSeries.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tools.MapboxTilesetCreate/TimeSeries.cs
@@ -6,13 +6,13 @@ public class TimeSeries
 {
     public long SiteId { get; set; }
     public long SiteVariableAmountId { get; set; }
-    public string SiteUuid { get; set; }
-    public string State { get; set; }
-    public string SiteType { get; set; }
-    public Geometry Location { get; set; }
+    public required string SiteUuid { get; set; }
+    public string? State { get; set; }
+    public string? SiteType { get; set; }
+    public required Geometry Location { get; set; }
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
-    public string PrimaryUseCagtegory { get; set; }
-    public string VariableType { get; set; }
-    public string WaterSourceType { get; set; }
+    public string? PrimaryUseCagtegory { get; set; }
+    public string? VariableType { get; set; }
+    public string? WaterSourceType { get; set; }
 }


### PR DESCRIPTION
MapboxTilesetCreate tool when ran against QA was timing out the database and the dbo.TimeSeriesView would take an extremely long time to return a small amount of data. This PR reworks how we retrieve time series sites for generating the map tiles.

Time Series will sort by SiteID then by SiteVariableAmountId paginate at 50K records. After each query it loops thru all the 50K records and checks when the SiteID changes. When it changes that indicates we've read all the time series for that site, so we generate a GeoJSON feature which has site information as well as all water sources, variable types and primary uses. Once all records in the database has been ran it generates the GeoJSON files.

This tool takes 30 minutes to write water rights, overlays and time series in QA. Against production this will likely take a few hours due to time series has 30M records.

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
