### PR TITLE
check for overlay types before rendering legend

### DIFF
--- a/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/hooks/useOverlayTypeLegend.tsx
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/hooks/useOverlayTypeLegend.tsx
@@ -26,6 +26,10 @@ export function useOverlayTypeLegend() {
   }, [renderedFeatures, overlayTypeColors, visibleOverlayTypes]);
 
   const legendItems = useMemo(() => {
+    if (renderedOverlayTypes.length === 0) {
+      return undefined;
+    }
+
     return renderedOverlayTypes.map((colorObj) => (
       <MapLegendCircleItem key={colorObj.key} color={colorObj.color}>
         {colorObj.key}


### PR DESCRIPTION
This PR addresses the bug where "Overlay Info" in the map legend always appeared even when Overlays wasn't turned on.

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

![Screen Recording 2025-02-25 at 9 26 55 AM](https://github.com/user-attachments/assets/06301c6e-1c5e-4998-8af3-07721495eb66)
