### PR TITLE
Fixed Unmatched Overlay Filters Showing Their Borders

### DIFF
--- a/src/DashboardUI/src/components/home-page/water-rights-tab/sidebar-filtering/useFilters.ts
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/sidebar-filtering/useFilters.ts
@@ -46,6 +46,10 @@ export function useFilters() {
         filter: overlaysMapFilters,
       },
       {
+        layer: mapLayerNames.overlayTypesPolygonsBorderLayer,
+        filter: overlaysMapFilters,
+      },
+      {
         layer: mapLayerNames.timeSeriesPointsLayer,
         filter: combinedTimeSeriesFilter,
       },


### PR DESCRIPTION
Fixed bug where overlay borders were showing for overlays that were filtered out. We forgot to set the overlay filters on their border layer.

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

# Before Fix
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/f5f2ca56-8472-45fb-8968-bdd62b88f8cc" />

# After Fix
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/5c709164-9de6-40d3-88aa-072ff54c72fa" />
