### PR TITLE
Fixed: Reset All Filters Not Resetting Map Sites

### DIFF
--- a/src/DashboardUI/src/components/map/Map.tsx
+++ b/src/DashboardUI/src/components/map/Map.tsx
@@ -152,17 +152,10 @@ function Map({
     mapInstance.addControl(dc);
 
     const callback = () => {
-      const features = dc.getAll().features;
-      const polygon = features.find((f) => f.geometry.type === 'Polygon') as
-        | GeoJSON.Feature<GeoJSON.Polygon>
-        | undefined;
-
-      setDrawPolygon(polygon ?? null);
-
       if (handleMapDrawnPolygonChange) {
-        handleMapDrawnPolygonChange(features);
+        handleMapDrawnPolygonChange(dc.getAll().features);
       }
-    };
+    }
 
     mapInstance.on('draw.create', callback);
     mapInstance.on('draw.update', callback);


### PR DESCRIPTION
Resolved bug where "Reset All Filters" was not resetting the map. This also fixed not being able draw filter polygons.

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [ ] Did you perform a self-review before assigning reviewers?

# Fix

https://github.com/user-attachments/assets/00510a55-4ff2-4946-affa-14b6f318cfc8


# QA

https://github.com/user-attachments/assets/ccc88e61-23d5-482d-bae5-0d047ebc1269


