### PR TITLE
Analytics & Table Message When Water Rights Is Turned OFF

### DIFF
--- a/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/components/AnalyticsDataTable.tsx
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/components/AnalyticsDataTable.tsx
@@ -56,64 +56,74 @@ function AnalyticsDataTable() {
   return (
     <Table>
       <thead>
-        <tr>
-          <th>Allocation UUID</th>
-          <th>Priority Date</th>
-          <th>WaDE Owner Classification</th>
-          <th>Owner</th>
-          <th>WaDE Legal Status</th>
-          <th>Allocation Flow (CFS)</th>
-          <th>Allocation Volume (AF)</th>
-          <th>WaDE Beneficial Use</th>
-        </tr>
+      <tr>
+        <th>Allocation UUID</th>
+        <th>Priority Date</th>
+        <th>WaDE Owner Classification</th>
+        <th>Owner</th>
+        <th>WaDE Legal Status</th>
+        <th>Allocation Flow (CFS)</th>
+        <th>Allocation Volume (AF)</th>
+        <th>WaDE Beneficial Use</th>
+      </tr>
       </thead>
       <tbody>
-        {waterRightsSearchResults.waterRightsDetails?.length > 0 &&
-          waterRightsSearchResults?.waterRightsDetails.map((waterRightDetail) => {
-            return (
-              <tr key={waterRightDetail.allocationUuid}>
-                <td>
-                  <a
-                    href={`/details/right/${waterRightDetail.allocationUuid}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {waterRightDetail.allocationUuid}
-                  </a>
-                </td>
-                <td>
-                  <FormattedDate>{waterRightDetail.allocationPriorityDate}</FormattedDate>
-                </td>
-                <td>{waterRightDetail.ownerClassification}</td>
-                <td>{waterRightDetail.allocationOwner}</td>
-                <td>{waterRightDetail.allocationLegalStatus}</td>
-                <td>{formatNumber(waterRightDetail.allocationFlowCfs)}</td>
-                <td>{formatNumber(waterRightDetail.allocationVolumeAf)}</td>
-                <td>{waterRightDetail.beneficialUses.join(', ')}</td>
-              </tr>
-            );
-          })}
-        {waterRightsSearchResults.waterRightsDetails?.length === 0 && !isFetchingTableData && (
-          <tr key="noResults">
-            <td colSpan={8} align="center">
-              No results found
-            </td>
-          </tr>
-        )}
-        {hasMoreResults && !isFetchingTableData && (
-          <tr>
-            <td colSpan={8} align="center">
-              <Button onClick={handleLoadMoreResults}>Load more results</Button>
-            </td>
-          </tr>
-        )}
-        {isFetchingTableData && (
-          <tr>
-            <td colSpan={8} align="center">
-              Loading... <ProgressBar animated now={100} />
-            </td>
-          </tr>
-        )}
+      {searchCriteria.isWaterRightsFilterActive ? (
+        <>
+          {waterRightsSearchResults.waterRightsDetails?.length > 0 &&
+            waterRightsSearchResults?.waterRightsDetails.map((waterRightDetail) => {
+              return (
+                <tr key={waterRightDetail.allocationUuid}>
+                  <td>
+                    <a
+                      href={`/details/right/${waterRightDetail.allocationUuid}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {waterRightDetail.allocationUuid}
+                    </a>
+                  </td>
+                  <td>
+                    <FormattedDate>{waterRightDetail.allocationPriorityDate}</FormattedDate>
+                  </td>
+                  <td>{waterRightDetail.ownerClassification}</td>
+                  <td>{waterRightDetail.allocationOwner}</td>
+                  <td>{waterRightDetail.allocationLegalStatus}</td>
+                  <td>{formatNumber(waterRightDetail.allocationFlowCfs)}</td>
+                  <td>{formatNumber(waterRightDetail.allocationVolumeAf)}</td>
+                  <td>{waterRightDetail.beneficialUses.join(', ')}</td>
+                </tr>
+              );
+            })}
+          {waterRightsSearchResults.waterRightsDetails?.length === 0 && !isFetchingTableData && (
+            <tr key="noResults">
+              <td colSpan={8} align="center">
+                No results found
+              </td>
+            </tr>
+          )}
+          {hasMoreResults && !isFetchingTableData && (
+            <tr>
+              <td colSpan={8} align="center">
+                <Button onClick={handleLoadMoreResults}>Load more results</Button>
+              </td>
+            </tr>
+          )}
+          {isFetchingTableData && (
+            <tr>
+              <td colSpan={8} align="center">
+                Loading... <ProgressBar animated now={100}/>
+              </td>
+            </tr>
+          )}
+        </>
+      ) : (
+        <tr key="noResults">
+          <td colSpan={8} align="center">
+            No results found. Water rights must be enabled.
+          </td>
+        </tr>
+      )}
       </tbody>
     </Table>
   );

--- a/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/components/AnalyticsInfoGroupingDropdown.tsx
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/components/AnalyticsInfoGroupingDropdown.tsx
@@ -31,7 +31,7 @@ function AnalyticsInfoGroupingDropdown(props: AnalyticsInfoGroupingDropdownProps
   }, [response]);
 
   return (
-    <div className="mb-3 col-4">
+    <div className="mb-3 w-100">
       <label htmlFor="grouping-dropdown">Select Grouping</label>
       <Select<DropdownOption>
         id="grouping-dropdown"

--- a/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/hooks/useWaterRightsSearchCriteria.ts
+++ b/src/DashboardUI/src/components/home-page/water-rights-tab/map-options/hooks/useWaterRightsSearchCriteria.ts
@@ -31,6 +31,7 @@ export function useWaterRightsSearchCriteriaWithoutContext({ filters, nldiIds }:
     riverBasinNames,
     allocationOwner,
     states,
+    isWaterRightsFilterActive,
   } = filters;
 
   const searchCriteria: WaterRightsSearchCriteria = useMemo(() => {
@@ -51,6 +52,7 @@ export function useWaterRightsSearchCriteriaWithoutContext({ filters, nldiIds }:
       allocationOwner: allocationOwner,
       states: states,
       wadeSitesUuids: nldiIds,
+      isWaterRightsFilterActive: isWaterRightsFilterActive,
     };
   }, [
     beneficialUseNames,
@@ -69,6 +71,7 @@ export function useWaterRightsSearchCriteriaWithoutContext({ filters, nldiIds }:
     allocationOwner,
     states,
     nldiIds,
+    isWaterRightsFilterActive
   ]);
 
   return { searchCriteria };

--- a/src/DashboardUI/src/data-contracts/WaterRightsSearchCriteria.ts
+++ b/src/DashboardUI/src/data-contracts/WaterRightsSearchCriteria.ts
@@ -15,6 +15,7 @@ export interface WaterRightsSearchCriteria {
   podOrPou?: string;
   minimumPriorityDate?: Date;
   maximumPriorityDate?: Date;
+  isWaterRightsFilterActive: boolean;
 }
 
 export interface WaterRightsSearchCriteriaWithPaging extends WaterRightsSearchCriteria {


### PR DESCRIPTION
The Analytics & Table popup on the dashboard is driven off of Water Rights. With the latest changes made, you can turn on/off Water Rights. The popup will now show a message when water rights is turned OFF.

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?



https://github.com/user-attachments/assets/7a94721d-997e-46b0-985e-de05135932fd

