### PR TITLE
(2/x) Backend - EstimateConsumptiveUse updated to include EstimateLocation ids in Response object

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -146,7 +146,6 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
 
         return new ApplicationEstimateStoreResponse
         {
-            WaterConservationApplicationEstimateId = entity.Id,
             Details = DtoMapper.Map<ApplicationEstimateLocationDetails[]>(entity.Locations)
         };
     }

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -144,7 +144,11 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         await db.WaterConservationApplicationEstimates.AddAsync(entity);
         await db.SaveChangesAsync();
 
-        return new ApplicationStoreResponseBase();
+        return new ApplicationEstimateStoreResponse
+        {
+            WaterConservationApplicationEstimateId = entity.Id,
+            Details = DtoMapper.Map<ApplicationEstimateLocationDetails[]>(entity.Locations)
+        };
     }
 
     private async Task<WaterConservationApplicationCreateResponse> CreateWaterConservationApplication(WaterConservationApplicationCreateRequest request)

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -348,6 +348,9 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
 
             CreateMap<ApplicationSubmissionFieldDetail, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source)
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
+
+            CreateMap<EFWD.WaterConservationApplicationEstimateLocation, ApplicationEstimateLocationDetails>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Id));
         }
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateLocationDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateLocationDetails.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateLocationDetails
+{
+    public Guid WaterConservationApplicationEstimateLocationId { get; set; }
+
+    public string PolygonWkt { get; set; } = null!;
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateStoreResponse : ApplicationStoreResponseBase
+{
+    public Guid WaterConservationApplicationEstimateId { get; set; }
+
+    public ApplicationEstimateLocationDetails[] Details { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
@@ -2,7 +2,5 @@
 
 public class ApplicationEstimateStoreResponse : ApplicationStoreResponseBase
 {
-    public Guid WaterConservationApplicationEstimateId { get; set; }
-
     public ApplicationEstimateLocationDetails[] Details { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
@@ -2,6 +2,8 @@
 
 public class PolygonEtDataCollection
 {
+    public Guid WaterConservationApplicationEstimateLocationId { get; set; }
+
     public string PolygonWkt { get; set; }
 
     public double AverageYearlyEtInInches { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/PolygonEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/PolygonEtDataCollection.cs
@@ -2,6 +2,8 @@
 
 public class PolygonEtDataCollection
 {
+    public Guid WaterConservationApplicationEstimateLocationId { get; set; }
+
     public string PolygonWkt { get; set; }
 
     public double AverageYearlyEtInInches { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseRequestHandler.cs
@@ -43,7 +43,6 @@ public class EstimateConsumptiveUseRequestHandler : IRequestHandler<EstimateCons
         var dataCollections = multiPolygonYearlyEtResponse.DataCollections.Map<Contracts.Client.PolygonEtDataCollection[]>();
 
         EstimateConservationPaymentResponse estimateConservationPaymentResponse = null;
-        ApplicationEstimateStoreResponse storeEstimateResponse = null;
         if (request.CompensationRateDollars.HasValue)
         {
             var estimateConservationPaymentRequest = DtoMapper.Map<EstimateConservationPaymentRequest>((request, multiPolygonYearlyEtResponse));
@@ -57,7 +56,7 @@ public class EstimateConsumptiveUseRequestHandler : IRequestHandler<EstimateCons
                 estimateConservationPaymentResponse
             ));
 
-            storeEstimateResponse = (ApplicationEstimateStoreResponse)await ApplicationAccessor.Store(storeEstimateRequest);
+            var storeEstimateResponse = (ApplicationEstimateStoreResponse)await ApplicationAccessor.Store(storeEstimateRequest);
 
             // connect the EstimateLocation Ids to the ET data
             foreach (var collection in dataCollections)

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -417,6 +417,9 @@ public class ApplicationIntegrationTests : IntegrationTestBase
                 dbEstimateLocation.PolygonWkt.Should().Be(request.Polygons[0]);
                 dbEstimateLocation.PolygonAreaInAcres.Should().BeApproximately(memorialStadiumApproximateAreaInAcres, 0.01);
 
+                // double-check that the response data was cross-referenced successfully with the db EstimateLocations
+                response.DataCollections.First().WaterConservationApplicationEstimateLocationId.Should().Be(dbEstimateLocation.Id);
+
                 dbEstimateLocationConsumptiveUses.All(consumptiveUse =>
                 {
                     var yearMatches = consumptiveUse.Year >= startYear && consumptiveUse.Year < startYear + yearRange;


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the ApplicationAccessor to return a new response object containing the EstimateLocation ids. Updated the EstimateConsumptiveUseRequestHandler to expect this response object and to build its own response object using these ids so that the frontend will have them.

## Appearance
Performed the Estimate Consumptive Use operation on the frontend, response shown in network tab:
![image](https://github.com/user-attachments/assets/5d30822d-507d-401c-b464-f3812c2212ff)
