### PR TITLE
Application Dashboard: Remove link

### DIFF
--- a/src/DashboardUI/src/components/SiteNavbar.tsx
+++ b/src/DashboardUI/src/components/SiteNavbar.tsx
@@ -42,9 +42,6 @@ function SiteNavbar() {
   const showOrganizationDashboard =
     isFeatureEnabled('conservationEstimationTool') && (userOrganizationId != null || isGlobalAdmin);
 
-  const showWaterUserDashboard =
-    isFeatureEnabled('conservationEstimationTool') && userOrganizationId == null && !isGlobalAdmin;
-
   const showProfileEdit = isFeatureEnabled('conservationEstimationTool');
 
   return (
@@ -91,11 +88,6 @@ function SiteNavbar() {
                 {showOrganizationDashboard && (
                   <NavDropdown.Item as={Link} to="/application/organization/dashboard">
                     Application Dashboard
-                  </NavDropdown.Item>
-                )}
-                {showWaterUserDashboard && (
-                  <NavDropdown.Item as={Link} to="/application/dashboard">
-                    My Applications
                   </NavDropdown.Item>
                 )}
                 <NavDropdown.Item onClick={() => handleLogout(msalContext)}>Logout</NavDropdown.Item>


### PR DESCRIPTION
## Description

We are not implementing an Application Dashboard for the water user. The placeholder page was removed in PR #606. This is just removing the link from the dropdown menu so a water user doesn't try to navigate to where it used to be.

## Demo

![27522-menu](https://github.com/user-attachments/assets/53c30640-e655-4598-939a-f8fbac70fa6a)

![Screenshot 2025-03-25 at 09 19 05](https://github.com/user-attachments/assets/a477cb98-c105-4291-8674-0062fb8c473d)

---


Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
