### PR TITLE
Bugfix - dirty form check does not reset after updating application

### DIFF
--- a/src/DashboardUI/src/hooks/useDirtyFormCheck.tsx
+++ b/src/DashboardUI/src/hooks/useDirtyFormCheck.tsx
@@ -6,7 +6,7 @@ function useDirtyFormCheck(
   options: {
     isEnabled: boolean;
   },
-): boolean {
+): [boolean, (formValues: any) => void] {
   const [initialFormValue, setInitialFormValue] = useState<any>(null);
   const [isFormDirty, setIsFormDirty] = useState(false);
 
@@ -26,7 +26,12 @@ function useDirtyFormCheck(
     }
   }, [options.isEnabled, initialFormValue, formValues]);
 
-  return isFormDirty;
+  function reinitializeDirtyFormCheck(formValues: any) {
+    setInitialFormValue(JSON.parse(JSON.stringify(formValues)));
+    setIsFormDirty(false);
+  }
+
+  return [isFormDirty, reinitializeDirtyFormCheck];
 }
 
 export default useDirtyFormCheck;

--- a/src/DashboardUI/src/pages/application/review/form/ApplicationReviewFormPage.tsx
+++ b/src/DashboardUI/src/pages/application/review/form/ApplicationReviewFormPage.tsx
@@ -37,9 +37,12 @@ export function ApplicationReviewFormPage() {
   const formRef = useRef<HTMLFormElement>(null);
   const [formValidated, setFormValidated] = useState(false);
 
-  const isFormDirty = useDirtyFormCheck(state.conservationApplication.applicationSubmissionForm, {
-    isEnabled: !isApplicationLoading && !isFundingOrganizationLoading,
-  });
+  const [isFormDirty, reinitializeDirtyFormCheck] = useDirtyFormCheck(
+    state.conservationApplication.applicationSubmissionForm,
+    {
+      isEnabled: !isApplicationLoading && !isFundingOrganizationLoading,
+    },
+  );
 
   const alertNotImplemented = () => alert('Not implemented. This feature will be implemented in a future release.');
 
@@ -77,6 +80,7 @@ export function ApplicationReviewFormPage() {
     onSuccess: () => {
       toast.success('Application changes saved successfully.');
       setShowSaveChangesModal(false);
+      reinitializeDirtyFormCheck(state.conservationApplication.applicationSubmissionForm);
     },
     onError: () => {
       toast.error('Error saving application changes.');


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Fixed the dirty form check - it now resets after a technical reviewer updates an application.

## Appearance

demo video - verifying that, once a technical reviewer has saved changes, they cannot then click the "save changes" button to save the same changes again.


https://github.com/user-attachments/assets/a5b2f9e4-927b-43ab-a051-a130cb6c0b6a


