### PR TITLE
Control Locations (3/x) - OpenET SDK - RasterTimeSeriesPoint

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/Converters/RasterTimeSeriesPointRequestConverter.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/Converters/RasterTimeSeriesPointRequestConverter.cs
@@ -1,0 +1,60 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WesternStatesWater.WestDaat.Common.DataContracts.Converters;
+
+public class RasterTimeSeriesPointRequestConverter : JsonConverter<RasterTimeSeriesPointRequest>
+{
+    public override RasterTimeSeriesPointRequest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException("Deserialization is not supported for this object.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, RasterTimeSeriesPointRequest value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        // Combine DateRangeStart and DateRangeEnd into a "date_range" property
+        writer.WritePropertyName("date_range");
+        writer.WriteStartArray();
+        writer.WriteStringValue(value.DateRangeStart.ToString("yyyy-MM-dd"));
+        writer.WriteStringValue(value.DateRangeEnd.ToString("yyyy-MM-dd"));
+        writer.WriteEndArray();
+
+        // Geometry 
+        writer.WritePropertyName("geometry");
+        var convertedGeometry = ConvertGeometryCoordinatesToFlattenedArray(value.Geometry);
+        writer.WriteStartArray();
+        foreach (var coord in convertedGeometry)
+        {
+            writer.WriteNumberValue(coord);
+        }
+        writer.WriteEndArray();
+
+
+        // remaining fields
+        writer.WriteString("file_format", value.OutputExtension.ToString());
+        writer.WriteString("interval", value.Interval.ToString());
+        writer.WriteString("model", value.Model.ToString());
+        writer.WriteString("reference_et", value.ReferenceEt.ToString());
+        writer.WriteString("units", ConvertRasterTimeseriesUnits(value.OutputUnits));
+        writer.WriteString("variable", value.Variable.ToString());
+
+        writer.WriteEndObject();
+    }
+
+    private double[] ConvertGeometryCoordinatesToFlattenedArray(NetTopologySuite.Geometries.Geometry geometry)
+    {
+        return geometry.Coordinates.Select(c => new double[] { c.X, c.Y }).SelectMany(x => x).ToArray();
+    }
+
+    private string ConvertRasterTimeseriesUnits(RasterTimeSeriesOutputUnits outputUnits)
+    {
+        return outputUnits switch
+        {
+            RasterTimeSeriesOutputUnits.Millimeters => "mm",
+            RasterTimeSeriesOutputUnits.Inches => "in",
+            _ => throw new NotImplementedException($"Output units {outputUnits} not implemented"),
+        };
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeSeriesDatapoint.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeSeriesDatapoint.cs
@@ -2,7 +2,7 @@
 
 namespace WesternStatesWater.WestDaat.Common.DataContracts;
 
-public class RasterTimeSeriesPolygonResponseDatapoint
+public class RasterTimeSeriesDatapoint
 {
     [JsonPropertyName("time")]
     public DateOnly Time { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPointRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPointRequest.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json.Serialization;
+using WesternStatesWater.WestDaat.Common.DataContracts.Converters;
+
+namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+[JsonConverter(typeof(RasterTimeSeriesPointRequestConverter))]
+public class RasterTimeSeriesPointRequest
+{
+    /// <summary>
+    /// Inclusive start date.
+    /// </summary>
+    public DateOnly DateRangeStart { get; set; }
+
+    /// <summary>
+    /// Inclusive end date.
+    /// </summary>
+    public DateOnly DateRangeEnd { get; set; }
+
+    public NetTopologySuite.Geometries.Point Geometry { get; set; }
+
+    public RasterTimeSeriesInterval Interval { get; set; }
+
+    public RasterTimeSeriesModel Model { get; set; }
+
+    public RasterTimeSeriesReferenceEt ReferenceEt { get; set; }
+
+    public RasterTimeSeriesOutputUnits OutputUnits { get; set; }
+
+    public RasterTimeSeriesCollectionVariable Variable { get; set; }
+
+    public RasterTimeSeriesFileFormat OutputExtension { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPointResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPointResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
 
-public class RasterTimeSeriesPolygonResponse
+public class RasterTimeSeriesPointResponse
 {
     public RasterTimeSeriesDatapoint[] Data { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPolygonRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/RasterTimeseriesPolygonRequest.cs
@@ -16,7 +16,7 @@ public class RasterTimeSeriesPolygonRequest
     /// </summary>
     public DateOnly DateRangeEnd { get; set; }
 
-    public NetTopologySuite.Geometries.Geometry Geometry { get; set; }
+    public NetTopologySuite.Geometries.Polygon Geometry { get; set; }
 
     public RasterTimeSeriesInterval Interval { get; set; }
 

--- a/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
@@ -1,4 +1,5 @@
-﻿using WesternStatesWater.WestDaat.Common.DataContracts;
+﻿using NetTopologySuite.Geometries;
+using WesternStatesWater.WestDaat.Common.DataContracts;
 using WesternStatesWater.WestDaat.Utilities;
 
 namespace WesternStatesWater.WestDaat.Engines;
@@ -68,7 +69,7 @@ internal class CalculationEngine : ICalculationEngine
         var results = new List<PolygonEtDataCollection>();
         foreach (var polygon in request.Polygons)
         {
-            var polygonGeo = GeometryHelpers.GetGeometryByWkt(polygon.PolygonWkt);
+            var polygonGeo = GeometryHelpers.GetGeometryByWkt(polygon.PolygonWkt) as Polygon;
 
             var rasterRequest = new RasterTimeSeriesPolygonRequest
             {

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -451,7 +451,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
                     Data = Enumerable.Range(0, yearRange).Select(yearOffset =>
                         {
                             var time = DateOnly.FromDateTime(new DateTime(startYear + yearOffset, 1, 1));
-                            return Enumerable.Range(0, monthsInYear).Select(_ => new Common.DataContracts.RasterTimeSeriesPolygonResponseDatapoint
+                            return Enumerable.Range(0, monthsInYear).Select(_ => new Common.DataContracts.RasterTimeSeriesDatapoint
                             {
                                 Time = time,
                                 Evapotranspiration = 5, // 5in/month = 60in/year = 5ft/year
@@ -614,7 +614,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             {
                 Data =
                 [
-                    new Common.DataContracts.RasterTimeSeriesPolygonResponseDatapoint
+                    new Common.DataContracts.RasterTimeSeriesDatapoint
                     {
                         Time = DateOnly.FromDateTime(new DateTime(startYear, 1, 1)),
                         Evapotranspiration = 5,

--- a/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
@@ -323,4 +323,127 @@ public class OpenEtSdkTests : UtilityTestBase
         serializedRequest.Should().Be(expectedJson);
     }
 
+    [DataTestMethod]
+    [DataRow(RasterTimeSeriesOutputUnits.Millimeters)]
+    [DataRow(RasterTimeSeriesOutputUnits.Inches)]
+    public async Task RasterTimeseriesPoint_MockedApi_Success(RasterTimeSeriesOutputUnits outputUnits)
+    {
+        // Arrange
+        var responseContentString = """
+        [
+            {
+                "time":"2024-01-01",
+                "et":16.184
+            },
+            {
+                "time":"2024-02-01",
+                "et":27.359
+            },
+            {
+                "time":"2024-03-01",
+                "et":46.508
+            },
+            {
+                "time":"2024-04-01",
+                "et":54.863
+            },
+            {
+                "time":"2024-05-01",
+                "et":93.419
+            },
+            {
+                "time":"2024-06-01",
+                "et":118.884
+            },
+            {
+                "time":"2024-07-01",
+                "et":136.422
+            },
+            {
+                "time":"2024-08-01",
+                "et":117.174
+            },
+            {
+                "time":"2024-09-01",
+                "et":93.941
+            },
+            {
+                "time":"2024-10-01",
+                "et":70.393
+            },
+            {
+                "time":"2024-11-01",
+                "et":26.606
+            },
+            {
+                "time":"2024-12-01",
+                "et":17.882
+            }
+        ]
+        """;
+        _mockHttp.When(HttpMethod.Post, baseAddress + "raster/timeseries/point")
+            .Respond("application/json", responseContentString);
+
+        var lastYear = new DateTime(DateTime.Now.Year - 1, 1, 1);
+        var currentYear = new DateTime(DateTime.Now.Year, 1, 1);
+        var pointCoordinate = new Coordinate(-119.7937, 35.58995);
+
+        var request = new RasterTimeSeriesPointRequest
+        {
+            DateRangeStart = DateOnly.FromDateTime(lastYear),
+            DateRangeEnd = DateOnly.FromDateTime(currentYear),
+            Geometry = new GeometryFactory().CreatePoint(pointCoordinate),
+            Interval = RasterTimeSeriesInterval.Monthly,
+            Model = RasterTimeSeriesModel.SSEBop,
+            ReferenceEt = RasterTimeSeriesReferenceEt.GridMET,
+            OutputExtension = RasterTimeSeriesFileFormat.JSON,
+            OutputUnits = outputUnits,
+            Variable = RasterTimeSeriesCollectionVariable.ET,
+        };
+
+        // Act
+        var sdk = CreateOpenEtSdk(_mockHttp.ToHttpClient());
+        var response = await sdk.RasterTimeseriesPoint(request);
+
+        // Assert
+        response.Should().NotBeNull();
+
+        const int monthsInYear = 12;
+        response.Data.Should().HaveCount(monthsInYear);
+        response.Data.All(datapoint => datapoint.Time.Year == lastYear.Year).Should().BeTrue();
+        response.Data.All(datapoint => datapoint.Evapotranspiration > 0).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task RasterTimeSeriesPoint_MockedApi_ApiError_ShouldThrow()
+    {
+        // Arrange
+        var lastYear = new DateTime(DateTime.Now.Year - 1, 1, 1);
+        var currentYear = new DateTime(DateTime.Now.Year, 1, 1);
+        var pointCoordinate = new Coordinate(-119.7937, 35.58995);
+
+        _mockHttp.When(HttpMethod.Post, baseAddress + "raster/timeseries/point")
+            .Respond(System.Net.HttpStatusCode.InternalServerError);
+
+        var request = new RasterTimeSeriesPointRequest
+        {
+            DateRangeStart = DateOnly.FromDateTime(lastYear),
+            DateRangeEnd = DateOnly.FromDateTime(currentYear),
+            Geometry = new GeometryFactory().CreatePoint(pointCoordinate),
+            Interval = RasterTimeSeriesInterval.Monthly,
+            Model = RasterTimeSeriesModel.SSEBop,
+            ReferenceEt = RasterTimeSeriesReferenceEt.GridMET,
+            OutputExtension = RasterTimeSeriesFileFormat.JSON,
+            OutputUnits = RasterTimeSeriesOutputUnits.Millimeters,
+            Variable = RasterTimeSeriesCollectionVariable.ET,
+        };
+
+        // Act
+        var sdk = CreateOpenEtSdk(_mockHttp.ToHttpClient());
+        var call = async () => await sdk.RasterTimeseriesPoint(request);
+
+        // Assert
+        await call.Should().ThrowAsync<ServiceUnavailableException>();
+    }
+
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
@@ -271,7 +271,7 @@ public class OpenEtSdkTests : UtilityTestBase
         // Assert
         response.Should().NotBeNull();
         response.Data.Length.Should().BeGreaterThan(0);
-        response.Data.All(datapoint => datapoint.Time.Year == lastYear.Year || datapoint.Time.Year == currentYear.Year).Should().BeTrue();
+        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year || datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
     }
 
     [TestMethod]
@@ -475,6 +475,6 @@ public class OpenEtSdkTests : UtilityTestBase
         // Assert
         response.Should().NotBeNull();
         response.Data.Length.Should().BeGreaterThan(0);
-        response.Data.All(datapoint => datapoint.Time.Year == lastYear.Year || datapoint.Time.Year == currentYear.Year).Should().BeTrue();
+        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year || datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
@@ -276,4 +276,51 @@ public class OpenEtSdkTests : UtilityTestBase
         response.Data.All(datapoint => datapoint.Time.Year == lastYear.Year).Should().BeTrue();
         response.Data.All(datapoint => datapoint.Evapotranspiration > 0).Should().BeTrue();
     }
+
+    [TestMethod]
+    public void RasterTimeSeriesPoint_RequestSerializesSuccessfully()
+    {
+        // Arrange
+        // remove whitespace from expected json
+        var expectedJson = Regex.Replace("""
+            {   
+                "date_range":["2024-01-01","2025-01-01"],
+                "geometry":[
+                    -119.7937,35.53326
+                ],
+                "file_format":"JSON",
+                "interval":"Monthly",
+                "model":"SSEBop",
+                "reference_et":"GridMET",
+                "units":"mm",
+                "variable":"ET"
+            }
+            """,
+            @"\s",
+            string.Empty);
+
+        var lastYear = new DateTime(DateTime.Now.Year - 1, 1, 1);
+        var currentYear = new DateTime(DateTime.Now.Year, 1, 1);
+        var pointCoordinate = new Coordinate(-119.7937, 35.53326);
+
+        var request = new RasterTimeSeriesPointRequest
+        {
+            DateRangeStart = DateOnly.FromDateTime(lastYear),
+            DateRangeEnd = DateOnly.FromDateTime(currentYear),
+            Geometry = new GeometryFactory().CreatePoint(pointCoordinate),
+            Interval = RasterTimeSeriesInterval.Monthly,
+            Model = RasterTimeSeriesModel.SSEBop,
+            ReferenceEt = RasterTimeSeriesReferenceEt.GridMET,
+            OutputExtension = RasterTimeSeriesFileFormat.JSON,
+            OutputUnits = RasterTimeSeriesOutputUnits.Millimeters,
+            Variable = RasterTimeSeriesCollectionVariable.ET,
+        };
+
+        // Act
+        var serializedRequest = JsonSerializer.Serialize(request);
+
+        // Assert
+        serializedRequest.Should().Be(expectedJson);
+    }
+
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Utilities.Tests/OpenEtSdkTests.cs
@@ -271,7 +271,7 @@ public class OpenEtSdkTests : UtilityTestBase
         // Assert
         response.Should().NotBeNull();
         response.Data.Length.Should().BeGreaterThan(0);
-        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year || datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
+        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year && datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
     }
 
     [TestMethod]
@@ -475,6 +475,6 @@ public class OpenEtSdkTests : UtilityTestBase
         // Assert
         response.Should().NotBeNull();
         response.Data.Length.Should().BeGreaterThan(0);
-        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year || datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
+        response.Data.All(datapoint => datapoint.Time.Year >= lastYear.Year && datapoint.Time.Year <= currentYear.Year).Should().BeTrue();
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Utilities/IOpenEtSdk.cs
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/IOpenEtSdk.cs
@@ -4,5 +4,7 @@ namespace WesternStatesWater.WestDaat.Utilities;
 
 public interface IOpenEtSdk
 {
+    Task<RasterTimeSeriesPointResponse> RasterTimeseriesPoint(RasterTimeSeriesPointRequest request);
+
     Task<RasterTimeSeriesPolygonResponse> RasterTimeseriesPolygon(RasterTimeSeriesPolygonRequest request);
 }

--- a/src/API/WesternStatesWater.WestDaat.Utilities/OpenEtSdk.cs
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/OpenEtSdk.cs
@@ -39,7 +39,7 @@ internal class OpenEtSdk : IOpenEtSdk
             }
 
             var responseContent = await response.Content.ReadAsStringAsync();
-            var responseData = JsonSerializer.Deserialize<RasterTimeSeriesPolygonResponseDatapoint[]>(responseContent);
+            var responseData = JsonSerializer.Deserialize<RasterTimeSeriesDatapoint[]>(responseContent);
 
             return new RasterTimeSeriesPolygonResponse
             {

--- a/src/API/WesternStatesWater.WestDaat.Utilities/OpenEtSdk.cs
+++ b/src/API/WesternStatesWater.WestDaat.Utilities/OpenEtSdk.cs
@@ -23,6 +23,35 @@ internal class OpenEtSdk : IOpenEtSdk
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Authorization, openEtConfiguration.ApiKey);
     }
 
+    public async Task<RasterTimeSeriesPointResponse> RasterTimeseriesPoint(RasterTimeSeriesPointRequest request)
+    {
+        try
+        {
+            var jsonString = JsonSerializer.Serialize(request);
+            var httpContent = new StringContent(jsonString, Encoding.UTF8, "application/json");
+
+            var uri = new Uri("raster/timeseries/point", UriKind.Relative);
+            var response = await _httpClient.PostAsync(uri, httpContent);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new ServiceUnavailableException($"OpenET API returned status code {response.StatusCode}");
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var responseData = JsonSerializer.Deserialize<RasterTimeSeriesDatapoint[]>(responseContent);
+
+            return new RasterTimeSeriesPointResponse
+            {
+                Data = responseData
+            };
+        }
+        catch (Exception e)
+        {
+            throw new ServiceUnavailableException("Error occurred while calling OpenET API", e);
+        }
+    }
+
     public async Task<RasterTimeSeriesPolygonResponse> RasterTimeseriesPolygon(RasterTimeSeriesPolygonRequest request)
     {
         try


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the `OpenEtSdk` to support the `RasterTimeSeriesPoint` api endpoint in anticipation of the new Control Locations. Added tests.

Also updated the `RasterTimeSeriesPolygonRequest` to expect a `Polygon` rather than the more generic `Geometry`.


## Appearance

verified that the "Real Api" tests pass:
![image](https://github.com/user-attachments/assets/ee2e67d9-3233-49f8-b639-9349f36b7252)
