### PR TITLE
[wip] Control Locations (5/x) - EstimateConsumptiveUse for Reviewer

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -229,7 +229,7 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         return new ApplicationEstimateStoreResponse
         {
             Details = DtoMapper.Map<ApplicationEstimateLocationDetails[]>(entity.Locations),
-            ControlLocationDetails = DtoMapper.Map<ApplicationEstimateControlLocationDetails>(entity.ControlLocations.Single())
+            ControlLocationDetails = DtoMapper.Map<ApplicationEstimateControlLocationDetails[]>(entity.ControlLocations).SingleOrDefault()
         };
     }
 

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -205,13 +205,13 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         var existingEntity = await db.WaterConservationApplicationEstimates
             .AsNoTracking()
             .Include(estimate => estimate.Locations)
-            .ThenInclude(location => location.ConsumptiveUses)
+            .ThenInclude(location => location.WaterMeasurements)
             .FirstOrDefaultAsync(estimate => estimate.WaterConservationApplicationId == request.WaterConservationApplicationId);
 
         if (existingEntity != null)
         {
             db.LocationWaterMeasurements
-                .RemoveRange(existingEntity.Locations.SelectMany(location => location.ConsumptiveUses));
+                .RemoveRange(existingEntity.Locations.SelectMany(location => location.WaterMeasurements));
 
             db.WaterConservationApplicationEstimateLocations.RemoveRange(existingEntity.Locations);
 
@@ -338,9 +338,9 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
             .ThenInclude(sub => sub.SubmissionNotes)
             .Where(a => a.Id == request.WaterConservationApplicationId)
             .SingleAsync();
-        
+
         DtoMapper.Map(request, application.Submission);
-        
+
         if (!string.IsNullOrEmpty(request.RecommendationNotes))
         {
             var note = request.Map<EFWD.WaterConservationApplicationSubmissionNote>();

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -328,7 +328,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.Ignore())
                 .ForMember(dest => dest.Estimate, opt => opt.Ignore())
                 .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore())
-                .ForMember(dest => dest.ConsumptiveUses, opt => opt.MapFrom(src => src.ConsumptiveUses));
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ConsumptiveUses));
 
             CreateMap<ApplicationEstimateStoreRequest, EFWD.WaterConservationApplicationEstimate>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -344,7 +344,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.WaterConservationApplication, opt => opt.Ignore())
                 .ForMember(dest => dest.CompensationRateDollars, opt => opt.MapFrom(src => src.DesiredCompensationDollars))
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.Locations))
-                .ForMember(dest => dest.ControlLocations, opt => opt.MapFrom(src => new[] { src.ControlLocation }))
+                .ForMember(dest => dest.ControlLocations, opt => opt.MapFrom(src => src.ControlLocation != null ? new[] { src.ControlLocation } : null))
                 .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.CumulativeTotalEtInAcreFeet))
                 .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.Ignore());
 

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -384,7 +384,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                     opt => opt.MapFrom(src => src.RecommendationDecision == RecommendationDecision.For ? DateTimeOffset.UtcNow : (DateTimeOffset?)null))
                 .ForMember(dest => dest.RecommendedAgainstDate,
                     opt => opt.MapFrom(src => src.RecommendationDecision == RecommendationDecision.Against ? DateTimeOffset.UtcNow : (DateTimeOffset?)null));
-                
+
             CreateMap<WaterConservationApplicationRecommendationRequest, EFWD.WaterConservationApplicationSubmissionNote>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationSubmission, opt => opt.Ignore())
@@ -404,6 +404,10 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
 
             CreateMap<EFWD.WaterConservationApplicationEstimateLocation, ApplicationEstimateLocationDetails>()
                 .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Id));
+
+            // todo: is this mapping needed?
+            CreateMap<EFWD.WaterConservationApplicationEstimateControlLocation, ApplicationEstimateControlLocationDetails>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateControlLocationId, opt => opt.MapFrom(src => src.Id));
 
             CreateMap<EFWD.WaterConservationApplication, ApplicationDetails>()
                 .ForMember(dest => dest.Notes, opt =>

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -346,7 +346,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.Locations))
                 .ForMember(dest => dest.ControlLocations, opt => opt.MapFrom(src => src.ControlLocation != null ? new[] { src.ControlLocation } : null))
                 .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.CumulativeTotalEtInAcreFeet))
-                .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.Ignore());
+                .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.MapFrom(src => src.CumulativeNetEtInAcreFeet));
 
             CreateMap<WaterConservationApplicationCreateRequest, EFWD.WaterConservationApplication>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -319,9 +319,12 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<ApplicationEstimateStoreLocationConsumptiveUseDetails, EFWD.LocationWaterMeasurement>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.Ignore())
-                .ForMember(dest => dest.Location, opt => opt.Ignore())
-                .ForMember(dest => dest.EffectivePrecipitationInInches, opt => opt.Ignore())
-                .ForMember(dest => dest.NetEtInInches, opt => opt.Ignore());
+                .ForMember(dest => dest.Location, opt => opt.Ignore());
+
+            CreateMap<ApplicationEstimateStoreControlLocationWaterMeasurementsDetails, EFWD.ControlLocationWaterMeasurement>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplicationEstimateControlLocationId, opt => opt.Ignore())
+                .ForMember(dest => dest.Location, opt => opt.Ignore());
 
             CreateMap<ApplicationEstimateStoreLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
@@ -330,11 +333,18 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ConsumptiveUses));
 
+            CreateMap<ApplicationEstimateStoreControlLocationDetails, EFWD.WaterConservationApplicationEstimateControlLocation>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.Ignore())
+                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.WaterMeasurements));
+
             CreateMap<ApplicationEstimateStoreRequest, EFWD.WaterConservationApplicationEstimate>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplication, opt => opt.Ignore())
                 .ForMember(dest => dest.CompensationRateDollars, opt => opt.MapFrom(src => src.DesiredCompensationDollars))
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.Locations))
+                .ForMember(dest => dest.ControlLocations, opt => opt.MapFrom(src => new[] { src.ControlLocation }))
                 .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.CumulativeTotalEtInAcreFeet))
                 .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.Ignore());
 

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/ApplicationFunction.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/ApplicationFunction.cs
@@ -53,7 +53,7 @@ public class ApplicationFunction : FunctionBase
         ApplicationStoreResponseBase results = request switch
         {
             ApplicantEstimateConsumptiveUseRequest applicantRequest => await _applicationManager.Store<ApplicantEstimateConsumptiveUseRequest, ApplicantEstimateConsumptiveUseResponse>(applicantRequest),
-            EstimateConsumptiveUseReviewerRequest reviewerRequest => await _applicationManager.Store<EstimateConsumptiveUseReviewerRequest, EstimateConsumptiveUseReviewerResponse>(reviewerRequest),
+            ReviewerEstimateConsumptiveUseRequest reviewerRequest => await _applicationManager.Store<ReviewerEstimateConsumptiveUseRequest, ReviewerEstimateConsumptiveUseResponse>(reviewerRequest),
             _ => throw new NotImplementedException($"Request type {request.GetType()} is not implemented.")
         };
 

--- a/src/API/WesternStatesWater.WestDaat.Client.Functions/ApplicationFunction.cs
+++ b/src/API/WesternStatesWater.WestDaat.Client.Functions/ApplicationFunction.cs
@@ -50,9 +50,10 @@ public class ApplicationFunction : FunctionBase
     {
         var request = await ParseRequestBody<ApplicationStoreRequestBase>(req);
 
-        var results = request switch
+        ApplicationStoreResponseBase results = request switch
         {
             EstimateConsumptiveUseApplicantRequest applicantRequest => await _applicationManager.Store<EstimateConsumptiveUseApplicantRequest, EstimateConsumptiveUseApplicantResponse>(applicantRequest),
+            EstimateConsumptiveUseReviewerRequest reviewerRequest => await _applicationManager.Store<EstimateConsumptiveUseReviewerRequest, EstimateConsumptiveUseReviewerResponse>(reviewerRequest),
             _ => throw new NotImplementedException($"Request type {request.GetType()} is not implemented.")
         };
 

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateControlLocationDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateControlLocationDetails.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateControlLocationDetails
+{
+    public Guid WaterConservationApplicationEstimateControlLocationId { get; set; }
+
+    public string PointWkt { get; set; } = null!;
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreControlLocationDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreControlLocationDetails.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateStoreControlLocationDetails
+{
+    required public string PointWkt { get; set; }
+
+    required public ApplicationEstimateStoreControlLocationWaterMeasurementsDetails[] WaterMeasurements { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreControlLocationWaterMeasurementsDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreControlLocationWaterMeasurementsDetails.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateStoreControlLocationWaterMeasurementsDetails
+{
+    required public int Year { get; set; }
+
+    required public double TotalEtInInches { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreLocationConsumptiveUseDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreLocationConsumptiveUseDetails.cs
@@ -5,4 +5,8 @@ public class ApplicationEstimateStoreLocationConsumptiveUseDetails
     required public int Year { get; set; }
 
     required public double TotalEtInInches { get; set; }
+
+    required public double? EffectivePrecipitationInInches { get; set; } = null!;
+
+    required public double? NetEtInInches { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreRequest.cs
@@ -24,5 +24,9 @@ public class ApplicationEstimateStoreRequest : ApplicationStoreRequestBase
 
     required public double CumulativeTotalEtInAcreFeet { get; set; }
 
+    required public double? CumulativeNetEtInAcreFeet { get; set; } = null!;
+
     required public ApplicationEstimateStoreLocationDetails[] Locations { get; set; }
+
+    required public ApplicationEstimateStoreControlLocationDetails ControlLocation { get; set; } = null;
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateStoreResponse.cs
@@ -3,4 +3,6 @@
 public class ApplicationEstimateStoreResponse : ApplicationStoreResponseBase
 {
     public ApplicationEstimateLocationDetails[] Details { get; set; }
+
+    public ApplicationEstimateControlLocationDetails ControlLocationDetails { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/GeometryEtDatapoint.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/GeometryEtDatapoint.cs
@@ -1,6 +1,6 @@
-﻿namespace WesternStatesWater.WestDaat.Contracts.Client;
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
 
-public class PolygonEtDatapoint
+public class GeometryEtDatapoint
 {
     public int Year { get; set; }
 

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/LocationDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/LocationDetails.cs
@@ -12,5 +12,5 @@ public class LocationDetails
 
     public string AdditionalDetails { get; set; } = null!;
 
-    public ConsumptiveUseDetails[] ConsumptiveUses { get; set; } = null!;
+    public ConsumptiveUseDetails[] WaterMeasurements { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPoint.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPoint.cs
@@ -1,0 +1,11 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class MapPoint
+{
+    /// <summary>
+    /// Point in "Well-known text" (WKT) format.
+    /// <br />
+    /// <see href="https://libgeos.org/specifications/wkt/">WKT Format Specification</see>.
+    /// </summary>
+    public string PointWkt { get; set; } = null!;
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPolygon.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPolygon.cs
@@ -3,7 +3,7 @@
 public class MapPolygon
 {
     /// <summary>
-    /// Polygon(s) in "Well-known text" (WKT) format.
+    /// Polygon in "Well-known text" (WKT) format.
     /// <br />
     /// <see href="https://libgeos.org/specifications/wkt/">WKT Format Specification</see>.
     /// </summary>

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MultiPolygonYearlyEtRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MultiPolygonYearlyEtRequest.cs
@@ -4,6 +4,8 @@ public class MultiPolygonYearlyEtRequest : CalculateRequestBase
 {
     public MapPolygon[] Polygons { get; set; }
 
+    public MapPoint ControlLocation { get; set; }
+
     public RasterTimeSeriesModel Model { get; set; }
 
     /// <summary>

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MultiPolygonYearlyEtResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MultiPolygonYearlyEtResponse.cs
@@ -3,4 +3,6 @@
 public class MultiPolygonYearlyEtResponse : CalculateResponseBase
 {
     public PolygonEtDataCollection[] DataCollections { get; set; }
+
+    public PointEtDataCollection ControlLocationDataCollection { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PointEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PointEtDataCollection.cs
@@ -1,0 +1,12 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class PointEtDataCollection
+{
+    public Guid WaterConservationApplicationEstimateControlLocationId { get; set; }
+
+    public string PointWkt { get; set; }
+
+    public double AverageYearlyTotalEtInInches { get; set; }
+
+    public GeometryEtDatapoint[] Datapoints { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
@@ -12,5 +12,9 @@ public class PolygonEtDataCollection
 
     public double AverageYearlyTotalEtInAcreFeet { get; set; }
 
+    public double? AverageYearlyNetEtInInches { get; set; }
+
+    public double? AverageYearlyNetEtInAcreFeet { get; set; }
+
     public PolygonEtDatapoint[] Datapoints { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/PolygonEtDataCollection.cs
@@ -16,5 +16,5 @@ public class PolygonEtDataCollection
 
     public double? AverageYearlyNetEtInAcreFeet { get; set; }
 
-    public PolygonEtDatapoint[] Datapoints { get; set; }
+    public GeometryEtDatapoint[] Datapoints { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/GeometryEtDatapoint.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/GeometryEtDatapoint.cs
@@ -1,6 +1,6 @@
-﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+﻿namespace WesternStatesWater.WestDaat.Contracts.Client;
 
-public class PolygonEtDatapoint
+public class GeometryEtDatapoint
 {
     public int Year { get; set; }
 

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/MapPoint.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/MapPoint.cs
@@ -1,13 +1,11 @@
 ﻿namespace WesternStatesWater.WestDaat.Contracts.Client;
 
-public class MapPolygon
+public class MapPoint
 {
     /// <summary>
-    /// Polygon in "Well-known text" (WKT) format.
+    /// Point in "Well-known text" (WKT) format.
     /// <br />
     /// <see href="https://libgeos.org/specifications/wkt/">WKT Format Specification</see>.
     /// </summary>
-    public string PolygonWkt { get; set; } = null!;
-
-    public Common.DataContracts.DrawToolType DrawToolType { get; set; }
+    public string PointWkt { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/PointEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/PointEtDataCollection.cs
@@ -1,0 +1,12 @@
+﻿namespace WesternStatesWater.WestDaat.Contracts.Client;
+
+public class PointEtDataCollection
+{
+    public Guid WaterConservationApplicationEstimateControlLocationId { get; set; }
+
+    public string PointWkt { get; set; }
+
+    public double AverageYearlyTotalEtInInches { get; set; }
+
+    public GeometryEtDatapoint[] Datapoints { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/PolygonEtDataCollection.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/PolygonEtDataCollection.cs
@@ -12,5 +12,9 @@ public class PolygonEtDataCollection
 
     public double AverageYearlyTotalEtInAcreFeet { get; set; }
 
-    public PolygonEtDatapoint[] Datapoints { get; set; }
+    public double? AverageYearlyNetEtInInches { get; set; }
+
+    public double? AverageYearlyNetEtInAcreFeet { get; set; }
+
+    public GeometryEtDatapoint[] Datapoints { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 [JsonDerivedType(typeof(WaterConservationApplicationSubmissionRequest), typeDiscriminator: nameof(WaterConservationApplicationSubmissionRequest))]
 [JsonDerivedType(typeof(WaterConservationApplicationRecommendationRequest), typeDiscriminator: nameof(WaterConservationApplicationRecommendationRequest))]
 [JsonDerivedType(typeof(EstimateConsumptiveUseApplicantRequest), typeDiscriminator: nameof(EstimateConsumptiveUseApplicantRequest))]
+[JsonDerivedType(typeof(EstimateConsumptiveUseReviewerRequest), typeDiscriminator: nameof(EstimateConsumptiveUseReviewerRequest))]
 public class ApplicationStoreRequestBase : RequestBase
 {
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
@@ -6,7 +6,7 @@ namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 [JsonDerivedType(typeof(WaterConservationApplicationSubmissionRequest), typeDiscriminator: nameof(WaterConservationApplicationSubmissionRequest))]
 [JsonDerivedType(typeof(WaterConservationApplicationRecommendationRequest), typeDiscriminator: nameof(WaterConservationApplicationRecommendationRequest))]
 [JsonDerivedType(typeof(ApplicantEstimateConsumptiveUseRequest), typeDiscriminator: nameof(ApplicantEstimateConsumptiveUseRequest))]
-[JsonDerivedType(typeof(EstimateConsumptiveUseReviewerRequest), typeDiscriminator: nameof(EstimateConsumptiveUseReviewerRequest))]
+[JsonDerivedType(typeof(ReviewerEstimateConsumptiveUseRequest), typeDiscriminator: nameof(ReviewerEstimateConsumptiveUseRequest))]
 public class ApplicationStoreRequestBase : RequestBase
 {
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequest.cs
@@ -4,8 +4,6 @@ public class EstimateConsumptiveUseReviewerRequest : ApplicationStoreRequestBase
 {
     public Guid WaterConservationApplicationId { get; set; }
 
-    public string WaterRightNativeId { get; set; } = null!;
-
     public MapPolygon[] Polygons { get; set; }
 
     public MapPoint ControlLocation { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
+
+public class EstimateConsumptiveUseReviewerRequest : ApplicationStoreRequestBase
+{
+    public Guid WaterConservationApplicationId { get; set; }
+
+    public string WaterRightNativeId { get; set; } = null!;
+
+    public MapPolygon[] Polygons { get; set; }
+
+    public MapPoint ControlLocation { get; set; }
+
+    public bool OverwriteEstimate { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/EstimateConsumptiveUseReviewerRequestValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+
+namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
+
+public class EstimateConsumptiveUseReviewerRequestValidator : AbstractValidator<EstimateConsumptiveUseReviewerRequest>
+{
+    public EstimateConsumptiveUseReviewerRequestValidator()
+    {
+        RuleFor(x => x.WaterConservationApplicationId).NotEmpty();
+
+        RuleFor(x => x.WaterRightNativeId).NotEmpty();
+
+        RuleFor(x => x.Polygons).NotEmpty().Must(polygons => polygons.Length <= 20);
+        RuleForEach(x => x.Polygons).ChildRules(polygonEntryValidator =>
+        {
+            polygonEntryValidator.RuleFor(polygon => polygon).NotNull();
+            polygonEntryValidator.RuleFor(polygon => polygon.PolygonWkt).NotEmpty();
+            polygonEntryValidator.RuleFor(polygon => polygon.DrawToolType).NotEmpty();
+        });
+
+        RuleFor(x => x.ControlLocation).NotEmpty();
+        RuleFor(x => x.ControlLocation.PointWkt).NotEmpty().MaximumLength(100).Must(pointWkt => pointWkt.Contains("POINT"));
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 
-public class EstimateConsumptiveUseReviewerRequest : ApplicationStoreRequestBase
+public class ReviewerEstimateConsumptiveUseRequest : ApplicationStoreRequestBase
 {
     public Guid WaterConservationApplicationId { get; set; }
 

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
@@ -8,8 +8,6 @@ public class ReviewerEstimateConsumptiveUseRequestValidator : AbstractValidator<
     {
         RuleFor(x => x.WaterConservationApplicationId).NotEmpty();
 
-        RuleFor(x => x.WaterRightNativeId).NotEmpty();
-
         RuleFor(x => x.Polygons).NotEmpty().Must(polygons => polygons.Length <= 20);
         RuleForEach(x => x.Polygons).ChildRules(polygonEntryValidator =>
         {

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
@@ -2,9 +2,9 @@
 
 namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 
-public class EstimateConsumptiveUseReviewerRequestValidator : AbstractValidator<EstimateConsumptiveUseReviewerRequest>
+public class ReviewerEstimateConsumptiveUseRequestValidator : AbstractValidator<ReviewerEstimateConsumptiveUseRequest>
 {
-    public EstimateConsumptiveUseReviewerRequestValidator()
+    public ReviewerEstimateConsumptiveUseRequestValidator()
     {
         RuleFor(x => x.WaterConservationApplicationId).NotEmpty();
 

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/EstimateConsumptiveUseReviewerResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/EstimateConsumptiveUseReviewerResponse.cs
@@ -1,0 +1,20 @@
+﻿namespace WesternStatesWater.WestDaat.Contracts.Client.Responses.Conservation
+{
+    public class EstimateConsumptiveUseReviewerResponse : ApplicationStoreResponseBase
+    {
+        /// <summary>
+        /// The average yearly estimated total et in acre-feet for all polygons.
+        /// </summary>
+        public double CumulativeTotalEtInAcreFeet { get; set; }
+
+        /// <summary>
+        /// The total estimated conservation payment in dollars.
+        /// </summary>
+        public int? ConservationPayment { get; set; }
+
+        /// <summary>
+        /// The average yearly estimated consumptive use in acre-feet per polygon, as well as the yearly data points.
+        /// </summary>
+        public PolygonEtDataCollection[] DataCollections { get; set; }
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
@@ -15,11 +15,16 @@
         /// <summary>
         /// The total estimated conservation payment in dollars.
         /// </summary>
-        public int? ConservationPayment { get; set; }
+        public int ConservationPayment { get; set; }
 
         /// <summary>
-        /// The average yearly estimated consumptive use in acre-feet per polygon, as well as the yearly data points.
+        /// A summary of estimated consumptive use data per location, along with each location's yearly data points.
         /// </summary>
         public PolygonEtDataCollection[] DataCollections { get; set; }
+
+        /// <summary>
+        /// A summary of estimated consumptive use data for the control location, along with its yearly data points.
+        /// </summary>
+        public PointEtDataCollection ControlDataCollection { get; set; }
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace WesternStatesWater.WestDaat.Contracts.Client.Responses.Conservation
 {
-    public class EstimateConsumptiveUseReviewerResponse : ApplicationStoreResponseBase
+    public class ReviewerEstimateConsumptiveUseResponse : ApplicationStoreResponseBase
     {
         /// <summary>
         /// The average yearly estimated total et in acre-feet for all polygons.

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Responses/Conservation/ReviewerEstimateConsumptiveUseResponse.cs
@@ -8,6 +8,11 @@
         public double CumulativeTotalEtInAcreFeet { get; set; }
 
         /// <summary>
+        /// The average yearly estimated net et in acre-feet for all polygons.
+        /// </summary>
+        public double CumulativeNetEtInAcreFeet { get; set; }
+
+        /// <summary>
         /// The total estimated conservation payment in dollars.
         /// </summary>
         public int? ConservationPayment { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimate.cs
+++ b/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimate.cs
@@ -31,4 +31,6 @@ public class WaterConservationApplicationEstimate
     public virtual WaterConservationApplication WaterConservationApplication { get; set; } = null!;
 
     public virtual ICollection<WaterConservationApplicationEstimateLocation> Locations { get; set; } = null!;
+
+    public virtual ICollection<WaterConservationApplicationEstimateControlLocation> ControlLocations { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimateLocation.cs
+++ b/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimateLocation.cs
@@ -21,5 +21,5 @@ public class WaterConservationApplicationEstimateLocation
 
     public virtual WaterConservationApplicationEstimate Estimate { get; set; } = null!;
 
-    public virtual ICollection<LocationWaterMeasurement> ConsumptiveUses { get; set; } = null!;
+    public virtual ICollection<LocationWaterMeasurement> WaterMeasurements { get; set; } = null!;
 }

--- a/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimateLocation.cs
+++ b/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationEstimateLocation.cs
@@ -17,7 +17,7 @@ public class WaterConservationApplicationEstimateLocation
 
     public double PolygonAreaInAcres { get; set; }
 
-    public string AdditionalDetails { get; set; } = null!;
+    public string? AdditionalDetails { get; set; } = null!;
 
     public virtual WaterConservationApplicationEstimate Estimate { get; set; } = null!;
 

--- a/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
@@ -71,6 +71,7 @@ internal class CalculationEngine : ICalculationEngine
     private async Task<MultiPolygonYearlyEtResponse> CalculatePolygonsEt(MultiPolygonYearlyEtRequest request)
     {
         double? controlLocationAverageTotalEtInInches = null;
+        Dictionary<int, double> controlLocationTotalEtByYear = null;
 
         // The Control Location is the location of an unirrigated field near the polygons.
         // This allows us to estimate the "Net ET" via this formula:
@@ -100,6 +101,8 @@ internal class CalculationEngine : ICalculationEngine
                 .ToArray();
 
             controlLocationAverageTotalEtInInches = yearlyDatapoints.Average(d => d.TotalEtInInches);
+
+            controlLocationTotalEtByYear = yearlyDatapoints.ToDictionary(datapoint => datapoint.Year, datapoint => datapoint.TotalEtInInches);
         }
 
         var results = new List<PolygonEtDataCollection>();
@@ -152,8 +155,9 @@ internal class CalculationEngine : ICalculationEngine
                 // update each datapoint
                 foreach (var datapoint in result.Datapoints)
                 {
-                    datapoint.EffectivePrecipitationInInches = controlLocationAverageTotalEtInInches;
-                    datapoint.NetEtInInches = datapoint.TotalEtInInches - controlLocationAverageTotalEtInInches;
+                    var controlLocationTotalEt = controlLocationTotalEtByYear[datapoint.Year];
+                    datapoint.EffectivePrecipitationInInches = controlLocationTotalEt;
+                    datapoint.NetEtInInches = datapoint.TotalEtInInches - controlLocationTotalEt;
                 }
             }
 

--- a/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
@@ -53,7 +53,11 @@ internal class CalculationEngine : ICalculationEngine
         foreach (var collection in request.DataCollections)
         {
             var acreage = GeometryHelpers.GetGeometryAreaInAcres(GeometryHelpers.GetGeometryByWkt(collection.PolygonWkt));
-            var averageEtInFeet = collection.AverageYearlyTotalEtInInches / 12;
+
+            // prefer Net ET if it's been computed, otherwise use Total ET
+            var etMetricToUse = collection.AverageYearlyNetEtInInches ?? collection.AverageYearlyTotalEtInInches;
+
+            var averageEtInFeet = etMetricToUse / 12;
             var averageEtInAcreFeet = averageEtInFeet * acreage;
             estimatedCompensation += averageEtInAcreFeet * request.CompensationRateDollars;
         }

--- a/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
@@ -261,6 +261,11 @@ internal class ValidationEngine : IValidationEngine
             OrganizationId = applicationExistsResponse.FundingOrganizationId
         });
 
+        if (!permissions.Contains(Permissions.ApplicationUpdate))
+        {
+            return CreateForbiddenError(request, context);
+        }
+
         // control location must not intersect with any polygons
         // polygons must not intersect with each other
         var controlLocationGeometry = GeometryHelpers.GetGeometryByWkt(request.ControlLocation.PointWkt) as NetTopologySuite.Geometries.Point;

--- a/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
@@ -169,7 +169,7 @@ internal class ValidationEngine : IValidationEngine
         return request switch
         {
             ApplicantEstimateConsumptiveUseRequest req => await ValidateApplicantEstimateConsumptiveUseRequest(req, context),
-            EstimateConsumptiveUseReviewerRequest req => await ValidateEstimateConsumptiveUseReviewerRequest(req, context),
+            ReviewerEstimateConsumptiveUseRequest req => await ValidateEstimateConsumptiveUseReviewerRequest(req, context),
             WaterConservationApplicationCreateRequest req => await ValidateWaterConservationApplicationCreateRequest(req, context),
             WaterConservationApplicationSubmissionRequest req => await ValidateWaterConservationApplicationSubmissionRequest(req, context),
             WaterConservationApplicationSubmissionUpdateRequest req => await ValidateWaterConservationApplicationSubmissionUpdateRequest(req, context),
@@ -236,7 +236,7 @@ internal class ValidationEngine : IValidationEngine
         return null;
     }
 
-    private async Task<ErrorBase> ValidateEstimateConsumptiveUseReviewerRequest(EstimateConsumptiveUseReviewerRequest request, ContextBase context)
+    private async Task<ErrorBase> ValidateEstimateConsumptiveUseReviewerRequest(ReviewerEstimateConsumptiveUseRequest request, ContextBase context)
     {
         // user must be logged in
         var userContext = _contextUtility.GetRequiredContext<UserContext>();
@@ -270,14 +270,14 @@ internal class ValidationEngine : IValidationEngine
         {
             if (controlLocationGeometry.Within(polygonGeometries[i]))
             {
-                return CreateValidationError(request, nameof(EstimateConsumptiveUseReviewerRequest.ControlLocation), "Control Location must not intersect with any polygons.");
+                return CreateValidationError(request, nameof(ReviewerEstimateConsumptiveUseRequest.ControlLocation), "Control Location must not intersect with any polygons.");
             }
 
             for (int j = i + 1; j < polygonGeometries.Length; j++)
             {
                 if (polygonGeometries[i].Intersects(polygonGeometries[j]))
                 {
-                    return CreateValidationError(request, nameof(EstimateConsumptiveUseReviewerRequest.Polygons), "Polygons must not intersect.");
+                    return CreateValidationError(request, nameof(ReviewerEstimateConsumptiveUseRequest.Polygons), "Polygons must not intersect.");
                 }
             }
         }

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseReviewerRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseReviewerRequestHandler.cs
@@ -1,0 +1,17 @@
+﻿using WesternStatesWater.Shared.Resolver;
+using WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
+using WesternStatesWater.WestDaat.Contracts.Client.Responses.Conservation;
+
+namespace WesternStatesWater.WestDaat.Managers.Handlers.Conservation;
+
+public class EstimateConsumptiveUseReviewerRequestHandler : IRequestHandler<EstimateConsumptiveUseReviewerRequest, EstimateConsumptiveUseReviewerResponse>
+{
+    public EstimateConsumptiveUseReviewerRequestHandler()
+    {
+    }
+
+    public async Task<EstimateConsumptiveUseReviewerResponse> Handle(EstimateConsumptiveUseReviewerRequest request)
+    {
+
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseReviewerRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/EstimateConsumptiveUseReviewerRequestHandler.cs
@@ -1,13 +1,31 @@
 ﻿using WesternStatesWater.Shared.Resolver;
+using WesternStatesWater.WestDaat.Accessors;
 using WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 using WesternStatesWater.WestDaat.Contracts.Client.Responses.Conservation;
+using WesternStatesWater.WestDaat.Engines;
+using WesternStatesWater.WestDaat.Utilities;
 
 namespace WesternStatesWater.WestDaat.Managers.Handlers.Conservation;
 
 public class EstimateConsumptiveUseReviewerRequestHandler : IRequestHandler<EstimateConsumptiveUseReviewerRequest, EstimateConsumptiveUseReviewerResponse>
 {
-    public EstimateConsumptiveUseReviewerRequestHandler()
+    public ICalculationEngine CalculationEngine { get; }
+    public IOpenEtSdk OpenEtSdk { get; }
+    public IApplicationAccessor ApplicationAccessor { get; }
+    public IOrganizationAccessor OrganizationAccessor { get; }
+    public IWaterAllocationAccessor WaterAllocationAccessor { get; }
+
+    public EstimateConsumptiveUseReviewerRequestHandler(ICalculationEngine calculationEngine,
+        IOpenEtSdk openEtSdk,
+        IApplicationAccessor applicationAccessor,
+        IOrganizationAccessor organizationAccessor,
+        IWaterAllocationAccessor waterAllocationAccessor)
     {
+        CalculationEngine = calculationEngine;
+        OpenEtSdk = openEtSdk;
+        ApplicationAccessor = applicationAccessor;
+        OrganizationAccessor = organizationAccessor;
+        WaterAllocationAccessor = waterAllocationAccessor;
     }
 
     public async Task<EstimateConsumptiveUseReviewerResponse> Handle(EstimateConsumptiveUseReviewerRequest request)

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
@@ -1,8 +1,10 @@
 ﻿using WesternStatesWater.Shared.Resolver;
 using WesternStatesWater.WestDaat.Accessors;
+using WesternStatesWater.WestDaat.Common.DataContracts;
 using WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 using WesternStatesWater.WestDaat.Contracts.Client.Responses.Conservation;
 using WesternStatesWater.WestDaat.Engines;
+using WesternStatesWater.WestDaat.Managers.Mapping;
 using WesternStatesWater.WestDaat.Utilities;
 
 namespace WesternStatesWater.WestDaat.Managers.Handlers.Conservation;
@@ -30,6 +32,51 @@ public class ReviewerEstimateConsumptiveUseRequestHandler : IRequestHandler<Revi
 
     public async Task<ReviewerEstimateConsumptiveUseResponse> Handle(ReviewerEstimateConsumptiveUseRequest request)
     {
+        // determine application's linked funding org
+        var applicationDetailsRequest = request.Map<ApplicationLoadSingleRequest>();
+        var applicationDetailsResponse = (ApplicationLoadSingleResponse)await ApplicationAccessor.Load(applicationDetailsRequest);
 
+        // we need funding org details to determine the parameters for computing each location's ET
+        var fundingOrgDetailsRequest = applicationDetailsResponse.Map<OrganizationFundingDetailsRequest>();
+        var fundingOrgDetailsResponse = (OrganizationFundingDetailsResponse)await OrganizationAccessor.Load(fundingOrgDetailsRequest);
+
+        // compute ET
+        var evapotranspirationRequest = DtoMapper.Map<MultiPolygonYearlyEtRequest>((request, fundingOrgDetailsResponse.Organization));
+        var evapotranspirationResponse = (MultiPolygonYearlyEtResponse)await CalculationEngine.Calculate(evapotranspirationRequest);
+
+        var dataCollections = evapotranspirationResponse.Map<Contracts.Client.PolygonEtDataCollection[]>();
+
+        EstimateConservationPaymentResponse estimateConservationPaymentResponse = null;
+        if (request.OverwriteEstimate)
+        {
+            var originalEstimate = applicationDetailsResponse.Application.Estimate;
+            var estimateConservationPaymentRequest = DtoMapper.Map<EstimateConservationPaymentRequest>((request, evapotranspirationResponse, originalEstimate));
+            estimateConservationPaymentResponse = (EstimateConservationPaymentResponse)await CalculationEngine.Calculate(estimateConservationPaymentRequest);
+
+            // store estimate
+            var storeEstimateRequest = DtoMapper.Map<ApplicationEstimateStoreRequest>((
+                request,
+                fundingOrgDetailsResponse.Organization,
+                evapotranspirationResponse,
+                estimateConservationPaymentResponse
+            ));
+
+            var storeEstimateResponse = (ApplicationEstimateStoreResponse)await ApplicationAccessor.Store(storeEstimateRequest);
+
+            // connect the EstimateLocation Ids to the ET data
+            foreach (var collection in dataCollections)
+            {
+                var matchingEstimateLocation = storeEstimateResponse.Details.Single(detail => detail.PolygonWkt == collection.PolygonWkt);
+                collection.WaterConservationApplicationEstimateLocationId = matchingEstimateLocation.WaterConservationApplicationEstimateLocationId;
+            }
+        }
+
+        return new ReviewerEstimateConsumptiveUseResponse
+        {
+            ConservationPayment = null,
+            CumulativeTotalEtInAcreFeet = evapotranspirationResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet),
+            CumulativeNetEtInAcreFeet = evapotranspirationResponse.DataCollections.Sum(dc => dc.AverageYearlyNetEtInAcreFeet.Value),
+            DataCollections = dataCollections,
+        };
     }
 }

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
@@ -7,7 +7,7 @@ using WesternStatesWater.WestDaat.Utilities;
 
 namespace WesternStatesWater.WestDaat.Managers.Handlers.Conservation;
 
-public class EstimateConsumptiveUseReviewerRequestHandler : IRequestHandler<EstimateConsumptiveUseReviewerRequest, EstimateConsumptiveUseReviewerResponse>
+public class ReviewerEstimateConsumptiveUseRequestHandler : IRequestHandler<ReviewerEstimateConsumptiveUseRequest, ReviewerEstimateConsumptiveUseResponse>
 {
     public ICalculationEngine CalculationEngine { get; }
     public IOpenEtSdk OpenEtSdk { get; }
@@ -15,7 +15,7 @@ public class EstimateConsumptiveUseReviewerRequestHandler : IRequestHandler<Esti
     public IOrganizationAccessor OrganizationAccessor { get; }
     public IWaterAllocationAccessor WaterAllocationAccessor { get; }
 
-    public EstimateConsumptiveUseReviewerRequestHandler(ICalculationEngine calculationEngine,
+    public ReviewerEstimateConsumptiveUseRequestHandler(ICalculationEngine calculationEngine,
         IOpenEtSdk openEtSdk,
         IApplicationAccessor applicationAccessor,
         IOrganizationAccessor organizationAccessor,
@@ -28,7 +28,7 @@ public class EstimateConsumptiveUseReviewerRequestHandler : IRequestHandler<Esti
         WaterAllocationAccessor = waterAllocationAccessor;
     }
 
-    public async Task<EstimateConsumptiveUseReviewerResponse> Handle(EstimateConsumptiveUseReviewerRequest request)
+    public async Task<ReviewerEstimateConsumptiveUseResponse> Handle(ReviewerEstimateConsumptiveUseRequest request)
     {
 
     }

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
@@ -50,13 +50,14 @@ public class ReviewerEstimateConsumptiveUseRequestHandler : IRequestHandler<Revi
         if (request.OverwriteEstimate)
         {
             var originalEstimate = applicationDetailsResponse.Application.Estimate;
-            var estimateConservationPaymentRequest = DtoMapper.Map<EstimateConservationPaymentRequest>((request, evapotranspirationResponse, originalEstimate));
+            var estimateConservationPaymentRequest = DtoMapper.Map<EstimateConservationPaymentRequest>((originalEstimate, evapotranspirationResponse));
             estimateConservationPaymentResponse = (EstimateConservationPaymentResponse)await CalculationEngine.Calculate(estimateConservationPaymentRequest);
 
             // store estimate
             var storeEstimateRequest = DtoMapper.Map<ApplicationEstimateStoreRequest>((
                 request,
                 fundingOrgDetailsResponse.Organization,
+                originalEstimate,
                 evapotranspirationResponse,
                 estimateConservationPaymentResponse
             ));

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -234,6 +234,20 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                     };
                 });
 
+            CreateMap<CommonContracts.PointEtDataCollection, CommonContracts.ApplicationEstimateStoreControlLocationDetails>()
+                .ConvertUsing((src, dest) =>
+                {
+                    return new CommonContracts.ApplicationEstimateStoreControlLocationDetails
+                    {
+                        PointWkt = src.PointWkt,
+                        WaterMeasurements = src.Datapoints.Select(datapoint => new CommonContracts.ApplicationEstimateStoreControlLocationWaterMeasurementsDetails
+                        {
+                            Year = datapoint.Year,
+                            TotalEtInInches = datapoint.TotalEtInInches,
+                        }).ToArray()
+                    };
+                });
+
             CreateMap<(
                     ClientContracts.Requests.Conservation.ApplicantEstimateConsumptiveUseRequest Request,
                     CommonContracts.OrganizationFundingDetails Organization,
@@ -272,7 +286,7 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.EtResponse.DataCollections))
                 .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)))
                 .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyNetEtInAcreFeet)))
-                .ForMember(dest => dest.ControlLocation, opt => opt.MapFrom(src => src.EtResponse.contro));
+                .ForMember(dest => dest.ControlLocation, opt => opt.MapFrom(src => src.EtResponse.ControlLocationDataCollection));
 
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationSubmissionRequest, CommonContracts.WaterConservationApplicationSubmissionRequest>();
 

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -214,6 +214,7 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
             CreateMap<CommonContracts.GeometryEtDatapoint, ClientContracts.GeometryEtDatapoint>();
 
             CreateMap<CommonContracts.PolygonEtDataCollection, ClientContracts.PolygonEtDataCollection>();
+            CreateMap<CommonContracts.PointEtDataCollection, ClientContracts.PointEtDataCollection>();
 
             CreateMap<CommonContracts.PolygonEtDataCollection, CommonContracts.ApplicationEstimateStoreLocationDetails>()
                 .ConvertUsing((src, dest) =>

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -211,7 +211,7 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateUnits))
                 .ForMember(dest => dest.DataCollections, opt => opt.MapFrom(src => src.EtData.DataCollections));
 
-            CreateMap<CommonContracts.PolygonEtDatapoint, ClientContracts.PolygonEtDatapoint>();
+            CreateMap<CommonContracts.GeometryEtDatapoint, ClientContracts.GeometryEtDatapoint>();
 
             CreateMap<CommonContracts.PolygonEtDataCollection, ClientContracts.PolygonEtDataCollection>();
 
@@ -228,6 +228,8 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                         {
                             Year = y.Year,
                             TotalEtInInches = y.TotalEtInInches,
+                            EffectivePrecipitationInInches = y.EffectivePrecipitationInInches,
+                            NetEtInInches = y.NetEtInInches
                         }).ToArray()
                     };
                 });
@@ -248,7 +250,10 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.Request.Units.Value))
                 .ForMember(dest => dest.EstimatedCompensationDollars, opt => opt.MapFrom(src => src.PaymentResponse.EstimatedCompensationDollars))
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.EtResponse.DataCollections))
-                .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)));
+                .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)))
+                // applicant does not provide a control location, thus no Net ET estimate is calculated
+                .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.Ignore())
+                .ForMember(dest => dest.ControlLocation, opt => opt.Ignore());
 
             CreateMap<(
                 ClientContracts.Requests.Conservation.ReviewerEstimateConsumptiveUseRequest Request,
@@ -265,7 +270,9 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateUnits))
                 .ForMember(dest => dest.EstimatedCompensationDollars, opt => opt.MapFrom(src => src.PaymentResponse.EstimatedCompensationDollars))
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.EtResponse.DataCollections))
-                .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)));
+                .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)))
+                .ForMember(dest => dest.CumulativeNetEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyNetEtInAcreFeet)))
+                .ForMember(dest => dest.ControlLocation, opt => opt.MapFrom(src => src.EtResponse.contro));
 
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationSubmissionRequest, CommonContracts.WaterConservationApplicationSubmissionRequest>();
 

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -170,18 +170,45 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
             CreateMap<ClientContracts.MapPolygon, CommonContracts.MapPolygon>()
                 .ReverseMap();
 
+            CreateMap<ClientContracts.MapPoint, CommonContracts.MapPoint>()
+                .ReverseMap();
+
+            CreateMap<ClientContracts.Requests.Conservation.ReviewerEstimateConsumptiveUseRequest, CommonContracts.ApplicationLoadSingleRequest>()
+                .ForMember(dest => dest.ApplicationId, opt => opt.MapFrom(src => src.WaterConservationApplicationId));
+
+            CreateMap<CommonContracts.ApplicationLoadSingleResponse, CommonContracts.OrganizationFundingDetailsRequest>()
+                .ForMember(dest => dest.OrganizationId, opt => opt.MapFrom(src => src.Application.FundingOrganizationId));
+
             CreateMap<
-                    (ClientContracts.Requests.Conservation.ApplicantEstimateConsumptiveUseRequest Request, CommonContracts.OrganizationFundingDetails Organization),
-                    CommonContracts.MultiPolygonYearlyEtRequest>()
+                (ClientContracts.Requests.Conservation.ApplicantEstimateConsumptiveUseRequest Request, CommonContracts.OrganizationFundingDetails Organization),
+                CommonContracts.MultiPolygonYearlyEtRequest>()
                 .ForMember(dest => dest.Polygons, opt => opt.MapFrom(src => src.Request.Polygons))
+                .ForMember(dest => dest.ControlLocation, opt => opt.Ignore())
                 .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Organization.OpenEtModel))
                 .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeStart))
                 .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeEnd));
 
-            CreateMap<(ClientContracts.Requests.Conservation.ApplicantEstimateConsumptiveUseRequest Request, CommonContracts.MultiPolygonYearlyEtResponse EtData),
-                    CommonContracts.EstimateConservationPaymentRequest>()
+            CreateMap<
+                (ClientContracts.Requests.Conservation.ReviewerEstimateConsumptiveUseRequest Request, CommonContracts.OrganizationFundingDetails Organization),
+                CommonContracts.MultiPolygonYearlyEtRequest>()
+                .ForMember(dest => dest.Polygons, opt => opt.MapFrom(src => src.Request.Polygons))
+                .ForMember(dest => dest.ControlLocation, opt => opt.MapFrom(src => src.Request.ControlLocation))
+                .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Organization.OpenEtModel))
+                .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeStart))
+                .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeEnd));
+
+            CreateMap<
+                (ClientContracts.Requests.Conservation.ApplicantEstimateConsumptiveUseRequest Request, CommonContracts.MultiPolygonYearlyEtResponse EtData),
+                CommonContracts.EstimateConservationPaymentRequest>()
                 .ForMember(dest => dest.CompensationRateDollars, opt => opt.MapFrom(src => src.Request.CompensationRateDollars))
                 .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.Request.Units))
+                .ForMember(dest => dest.DataCollections, opt => opt.MapFrom(src => src.EtData.DataCollections));
+
+            CreateMap<
+                (CommonContracts.EstimateDetails OriginalEstimate, CommonContracts.MultiPolygonYearlyEtResponse EtData),
+                CommonContracts.EstimateConservationPaymentRequest>()
+                .ForMember(dest => dest.CompensationRateDollars, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateDollars))
+                .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateUnits))
                 .ForMember(dest => dest.DataCollections, opt => opt.MapFrom(src => src.EtData.DataCollections));
 
             CreateMap<CommonContracts.PolygonEtDatapoint, ClientContracts.PolygonEtDatapoint>();
@@ -223,6 +250,23 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
                 .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.EtResponse.DataCollections))
                 .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)));
 
+            CreateMap<(
+                ClientContracts.Requests.Conservation.ReviewerEstimateConsumptiveUseRequest Request,
+                CommonContracts.OrganizationFundingDetails Organization,
+                CommonContracts.EstimateDetails OriginalEstimate,
+                CommonContracts.MultiPolygonYearlyEtResponse EtResponse,
+                CommonContracts.EstimateConservationPaymentResponse PaymentResponse),
+                CommonContracts.ApplicationEstimateStoreRequest>()
+                .ForMember(dest => dest.WaterConservationApplicationId, opt => opt.MapFrom(src => src.Request.WaterConservationApplicationId))
+                .ForMember(dest => dest.Model, opt => opt.MapFrom(src => src.Organization.OpenEtModel))
+                .ForMember(dest => dest.DateRangeStart, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeStart))
+                .ForMember(dest => dest.DateRangeEnd, opt => opt.MapFrom(src => src.Organization.OpenEtDateRangeEnd))
+                .ForMember(dest => dest.DesiredCompensationDollars, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateDollars))
+                .ForMember(dest => dest.CompensationRateUnits, opt => opt.MapFrom(src => src.OriginalEstimate.CompensationRateUnits))
+                .ForMember(dest => dest.EstimatedCompensationDollars, opt => opt.MapFrom(src => src.PaymentResponse.EstimatedCompensationDollars))
+                .ForMember(dest => dest.Locations, opt => opt.MapFrom(src => src.EtResponse.DataCollections))
+                .ForMember(dest => dest.CumulativeTotalEtInAcreFeet, opt => opt.MapFrom(src => src.EtResponse.DataCollections.Sum(dc => dc.AverageYearlyTotalEtInAcreFeet)));
+
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationSubmissionRequest, CommonContracts.WaterConservationApplicationSubmissionRequest>();
 
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationSubmissionUpdateRequest,
@@ -246,7 +290,7 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
             CreateMap<ClientContracts.Requests.Admin.ApplicationDocumentDownloadSasTokenRequest, CommonContracts.ApplicationDocumentLoadSingleRequest>();
 
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationSubmittedEvent, CommonContracts.WaterConservationApplicationSubmittedEvent>();
-            
+
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationRecommendationRequest, CommonContracts.WaterConservationApplicationRecommendationRequest>()
                 .ForMember(dest => dest.RecommendedByUserId, opt => opt.Ignore());
         }

--- a/src/API/WesternStatesWater.WestDaat.Tests.Helpers/WaterConservationApplicationEstimateFaker.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.Helpers/WaterConservationApplicationEstimateFaker.cs
@@ -26,3 +26,31 @@ public class WaterConservationApplicationEstimateFaker : Faker<EFWD.WaterConserv
         }
     }
 }
+
+public static class WaterConservationApplicationEstimateFakerExtensions
+{
+    public static Faker<EFWD.WaterConservationApplicationEstimate> GenerateMetadataFromOrganization(
+        this Faker<EFWD.WaterConservationApplicationEstimate> faker,
+        EFWD.Organization organization
+    )
+    {
+        faker.RuleFor(est => est.Model, () => organization.OpenEtModel);
+
+        faker.RuleFor(est => est.DateRangeStart, () =>
+            DateOnly.FromDateTime(
+                new DateTimeOffset(DateTimeOffset.UtcNow.Year - organization.OpenEtDateRangeInYears, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                .UtcDateTime
+            )
+        );
+
+        faker.RuleFor(est => est.DateRangeEnd, () =>
+            DateOnly.FromDateTime(
+                new DateTimeOffset(DateTimeOffset.UtcNow.Year, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                .AddMinutes(-1)
+                .UtcDateTime
+            )
+        );
+
+        return faker;
+    }
+}

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -846,7 +846,8 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             response.CumulativeNetEtInAcreFeet.Should().BeApproximately(expectedLocationsCumulativeNetEtInAcreFeet, 0.01);
 
             // - verify payment reuses original estimate's desired compensation dollars
-            var expectedConservationPayment = estimate.CompensationRateDollars * response.CumulativeTotalEtInAcreFeet;
+            // - verify payment calculates using Net ET instead of Total ET
+            var expectedConservationPayment = estimate.CompensationRateDollars * response.CumulativeNetEtInAcreFeet;
             response.ConservationPayment.Should().Be((int)expectedConservationPayment);
 
             var dbEstimate = await _dbContext.WaterConservationApplicationEstimates

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -350,7 +350,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
     [DataRow(false, true, DisplayName = "Create new estimate")]
     [DataRow(true, true, DisplayName = "Overwrite existing estimate")]
     [DataRow(false, false, DisplayName = "Request without compensation should not save estimate")]
-    public async Task Store_EstimateConsumptiveUse_AsUser_Success(
+    public async Task Store_ApplicantEstimateConsumptiveUse_AsUser_Success(
         bool shouldInitializePreviousEstimate,
         bool requestShouldIncludeCompensationInfo
     )
@@ -598,7 +598,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task Store_EstimateConsumptiveUse_AsAnonymous_Failure()
+    public async Task Store_ApplicantEstimateConsumptiveUse_AsAnonymous_Failure()
     {
         // Arrange
         var user = new UserFaker().Generate();

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -855,7 +855,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
                 .SingleOrDefaultAsync(estimate => estimate.WaterConservationApplicationId == application.Id);
             var dbEstimateLocation = dbEstimate?.Locations.First();
             var dbEstimateLocationWaterMeasurements = dbEstimateLocation?.WaterMeasurements;
-            var dbEstimateControlLocation = dbEstimate?.ControlLocations?.First();
+            var dbEstimateControlLocation = dbEstimate?.ControlLocations?.FirstOrDefault();
             var dbEstimateControlLocationWaterMeasurements = dbEstimateControlLocation?.WaterMeasurements;
 
             // estimate should always exist; it was either:

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -690,6 +690,8 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             _dbContext.WaterConservationApplicationEstimateControlLocations.RemoveRange(_dbContext.WaterConservationApplicationEstimateControlLocations);
             _dbContext.WaterConservationApplicationEstimateLocations.RemoveRange(_dbContext.WaterConservationApplicationEstimateLocations);
             _dbContext.WaterConservationApplicationEstimates.RemoveRange(_dbContext.WaterConservationApplicationEstimates);
+            _dbContext.WaterConservationApplicationSubmissionNotes.RemoveRange(_dbContext.WaterConservationApplicationSubmissionNotes);
+            _dbContext.WaterConservationApplicationSubmissions.RemoveRange(_dbContext.WaterConservationApplicationSubmissions);
             _dbContext.WaterConservationApplications.RemoveRange(_dbContext.WaterConservationApplications);
             _dbContext.UserProfiles.RemoveRange(_dbContext.UserProfiles);
             _dbContext.Users.RemoveRange(_dbContext.Users);
@@ -730,11 +732,13 @@ public class ApplicationIntegrationTests : IntegrationTestBase
 
             await _dbContext.WaterConservationApplications.AddAsync(application);
 
-            // estimate was created by applicant
             var estimate = new WaterConservationApplicationEstimateFaker(application).Generate();
             var estimateLocation = new WaterConservationApplicationEstimateLocationFaker(estimate).Generate();
             var estimateLocationConsumptiveUses = new LocationWaterMeasurementFaker(estimateLocation).Generate(12);
             await _dbContext.LocationWaterMeasurements.AddRangeAsync(estimateLocationConsumptiveUses);
+
+            var submission = new WaterConservationApplicationSubmissionFaker(application).Generate();
+            await _dbContext.WaterConservationApplicationSubmissions.AddAsync(submission);
 
             await _dbContext.SaveChangesAsync();
 

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -380,7 +380,9 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             wadeDb.ReportYearType.RemoveRange(wadeDb.ReportYearType);
             await wadeDb.SaveChangesAsync();
 
+            _dbContext.ControlLocationWaterMeasurements.RemoveRange(_dbContext.ControlLocationWaterMeasurements);
             _dbContext.LocationWaterMeasurements.RemoveRange(_dbContext.LocationWaterMeasurements);
+            _dbContext.WaterConservationApplicationEstimateControlLocations.RemoveRange(_dbContext.WaterConservationApplicationEstimateControlLocations);
             _dbContext.WaterConservationApplicationEstimateLocations.RemoveRange(_dbContext.WaterConservationApplicationEstimateLocations);
             _dbContext.WaterConservationApplicationEstimates.RemoveRange(_dbContext.WaterConservationApplicationEstimates);
             _dbContext.WaterConservationApplications.RemoveRange(_dbContext.WaterConservationApplications);

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -971,63 +971,67 @@ public class ApplicationIntegrationTests : IntegrationTestBase
         }
     }
 
-    //[TestMethod]
-    //public async Task Store_ReviewerEstimateConsumptiveUse_AsAnonymous_Failure()
-    //{
-    //    // Arrange
-    //    var user = new UserFaker().Generate();
-    //    var organization = new OrganizationFaker().Generate();
-    //    var application = new WaterConservationApplicationFaker(user, organization).Generate();
+    [TestMethod]
+    public async Task Store_ReviewerEstimateConsumptiveUse_AsAnonymous_Failure()
+    {
+        // Arrange
+        var user = new UserFaker().Generate();
+        var organization = new OrganizationFaker().Generate();
+        var application = new WaterConservationApplicationFaker(user, organization).Generate();
 
-    //    await _dbContext.WaterConservationApplications.AddAsync(application);
+        await _dbContext.WaterConservationApplications.AddAsync(application);
 
-    //    await _dbContext.SaveChangesAsync();
+        await _dbContext.SaveChangesAsync();
 
-    //    const int startYear = 2024;
-    //    OpenEtSdkMock.Setup(x => x.RasterTimeseriesPolygon(It.IsAny<Common.DataContracts.RasterTimeSeriesPolygonRequest>()))
-    //        .ReturnsAsync(new Common.DataContracts.RasterTimeSeriesPolygonResponse
-    //        {
-    //            Data =
-    //            [
-    //                new Common.DataContracts.RasterTimeSeriesDatapoint
-    //                {
-    //                    Time = DateOnly.FromDateTime(new DateTime(startYear, 1, 1)),
-    //                    Evapotranspiration = 5,
-    //                }
-    //            ]
-    //        });
+        const int startYear = 2024;
+        OpenEtSdkMock.Setup(x => x.RasterTimeseriesPolygon(It.IsAny<RasterTimeSeriesPolygonRequest>()))
+            .ReturnsAsync(new RasterTimeSeriesPolygonResponse
+            {
+                Data =
+                [
+                    new RasterTimeSeriesDatapoint
+                    {
+                        Time = DateOnly.FromDateTime(new DateTime(startYear, 1, 1)),
+                        Evapotranspiration = 5,
+                    }
+                ]
+            });
 
-    //    ContextUtilityMock.Setup(x => x.GetRequiredContext<UserContext>())
-    //        .Throws(new InvalidOperationException("User context is required for this operation"));
+        ContextUtilityMock.Setup(x => x.GetRequiredContext<UserContext>())
+            .Throws(new InvalidOperationException("User context is required for this operation"));
 
-    //    UseAnonymousContext();
+        UseAnonymousContext();
 
-    //    var request = new ApplicantEstimateConsumptiveUseRequest
-    //    {
-    //        WaterConservationApplicationId = application.Id,
-    //        WaterRightNativeId = application.WaterRightNativeId,
-    //        Polygons =
-    //        [
-    //            new CLI.MapPolygon
-    //            {
-    //                PolygonWkt = memorialStadiumFootballField,
-    //                DrawToolType = DrawToolType.Freeform,
-    //            }
-    //        ],
-    //    };
+        var request = new ReviewerEstimateConsumptiveUseRequest
+        {
+            WaterConservationApplicationId = application.Id,
+            OverwriteEstimate = false,
+            Polygons =
+            [
+                new CLI.MapPolygon
+                {
+                    PolygonWkt = memorialStadiumFootballField,
+                    DrawToolType = DrawToolType.Freeform,
+                }
+            ],
+            ControlLocation = new CLI.MapPoint
+            {
+                PointWkt = "POINT (0 0)",
+            }
+        };
 
-    //    // Act
-    //    var response = await _applicationManager.Store<
-    //        ApplicantEstimateConsumptiveUseRequest,
-    //        ApplicantEstimateConsumptiveUseResponse>(
-    //        request);
+        // Act
+        var response = await _applicationManager.Store<
+            ReviewerEstimateConsumptiveUseRequest,
+            ReviewerEstimateConsumptiveUseResponse>(
+            request);
 
-    //    // Assert
-    //    response.Should().NotBeNull();
-    //    response.Error.Should().NotBeNull();
+        // Assert
+        response.Should().NotBeNull();
+        response.Error.Should().NotBeNull();
 
-    //    ContextUtilityMock.Verify(x => x.GetRequiredContext<UserContext>(), Times.Once);
-    //}
+        ContextUtilityMock.Verify(x => x.GetRequiredContext<UserContext>(), Times.Once);
+    }
 
     [TestMethod]
     public async Task Store_CreateWaterConservationApplication_Success()


### PR DESCRIPTION
Pull Request Checklist

- [ ] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [ ] Did you include a descriptive title and description with your PR?
- [ ] Did you perform a self-review before assigning reviewers?

## Summary
Implemented the `EstimateConsumptiveUse` call chain, to be used by a technical reviewer.

The new call chain expects an additional parameter compared to the existing call chain - the Control Location. Using this control variable, it estimates the Net ET for each polygon, and then uses the Net ET to more accurately estimate what an applicant may receive in compensation.

The new call chain also allows the technical reviewer to specify whether they would like to overwrite the applicant's original estimate with the new one.

## Appearance
todo: postman success