### PR TITLE
Application Review: Accept/Deny Application - Data Contracts

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -353,6 +353,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.AcceptedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.RejectedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.SubmittedDate, opt => opt.MapFrom(_ => DateTimeOffset.UtcNow))
+                .ForMember(dest => dest.ApprovedByUserId, opt => opt.Ignore())
                 .ForMember(dest => dest.RecommendedByUserId, opt => opt.Ignore())
                 .ForMember(dest => dest.RecommendedForDate, opt => opt.Ignore())
                 .ForMember(dest => dest.RecommendedAgainstDate, opt => opt.Ignore());
@@ -363,6 +364,7 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.SubmissionNotes, opt => opt.Ignore())
                 .ForMember(dest => dest.AcceptedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.RejectedDate, opt => opt.Ignore())
+                .ForMember(dest => dest.ApprovedByUserId, opt => opt.Ignore())
                 .ForMember(dest => dest.SubmittedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.RecommendedByUserId, opt => opt.Ignore())
                 .ForMember(dest => dest.RecommendedForDate, opt => opt.Ignore())
@@ -393,6 +395,22 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.RecommendedByUserId))
                 .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(_ => DateTimeOffset.UtcNow))
                 .ForMember(dest => dest.Note, opt => opt.MapFrom(src => src.RecommendationNotes));
+
+            CreateMap<WaterConservationApplicationApprovalRequest, EFWD.WaterConservationApplicationSubmission>(MemberList.Source)
+                .ForSourceMember(src => src.WaterConservationApplicationId, opt => opt.DoNotValidate())
+                .ForSourceMember(src => src.ApprovalNotes, opt => opt.DoNotValidate())
+                .ForSourceMember(src => src.ApprovalDecision, opt => opt.DoNotValidate())
+                .ForMember(dest => dest.AcceptedDate, opt => opt.MapFrom(src => src.ApprovalDecision == ApprovalDecision.Accepted ? DateTimeOffset.UtcNow : (DateTimeOffset?)null))
+                .ForMember(dest => dest.RejectedDate, opt => opt.MapFrom(src => src.ApprovalDecision == ApprovalDecision.Rejected ? DateTimeOffset.UtcNow : (DateTimeOffset?)null));
+                
+            CreateMap<WaterConservationApplicationApprovalRequest, EFWD.WaterConservationApplicationSubmissionNote>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplicationSubmission, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplicationSubmissionId, opt => opt.Ignore())
+                .ForMember(dest => dest.User, opt => opt.Ignore())
+                .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.ApprovedByUserId))
+                .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(_ => DateTimeOffset.UtcNow))
+                .ForMember(dest => dest.Note, opt => opt.MapFrom(src => src.ApprovalNotes));
 
             CreateMap<WaterConservationApplicationDocument, EFWD.WaterConservationApplicationDocument>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApprovalDecision.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApprovalDecision.cs
@@ -1,0 +1,8 @@
+namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public enum ApprovalDecision
+{
+    Unknown = 0,
+    Accepted = 1,
+    Rejected = 2
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/SubmissionDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/SubmissionDetails.cs
@@ -10,6 +10,8 @@ public class SubmissionDetails
 
     public DateTimeOffset? RejectedDate { get; set; }
     
+    public Guid? ApprovedByUserId { get; set; }
+    
     public DateTimeOffset? RecommendedForDate { get; set; }
 
     public DateTimeOffset? RecommendedAgainstDate { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/WaterConservationApplicationApprovalRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/WaterConservationApplicationApprovalRequest.cs
@@ -1,0 +1,12 @@
+namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class WaterConservationApplicationApprovalRequest : ApplicationStoreRequestBase
+{
+    public Guid WaterConservationApplicationId { get; set; }
+    
+    public Guid ApprovedByUserId { get; set; }
+    
+    public ApprovalDecision ApprovalDecision { get; set; }
+    
+    public string ApprovalNotes { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicationStoreRequestBase.cs
@@ -3,6 +3,7 @@ using WesternStatesWater.Shared.DataContracts;
 
 namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
 
+[JsonDerivedType(typeof(WaterConservationApplicationApprovalRequest), typeDiscriminator: nameof(WaterConservationApplicationApprovalRequest))]
 [JsonDerivedType(typeof(WaterConservationApplicationSubmissionRequest), typeDiscriminator: nameof(WaterConservationApplicationSubmissionRequest))]
 [JsonDerivedType(typeof(WaterConservationApplicationRecommendationRequest), typeDiscriminator: nameof(WaterConservationApplicationRecommendationRequest))]
 [JsonDerivedType(typeof(ApplicantEstimateConsumptiveUseRequest), typeDiscriminator: nameof(ApplicantEstimateConsumptiveUseRequest))]

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/WaterConservationApplicationApprovalRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/WaterConservationApplicationApprovalRequest.cs
@@ -1,0 +1,12 @@
+using WesternStatesWater.WestDaat.Common.DataContracts;
+
+namespace WesternStatesWater.WestDaat.Contracts.Client.Requests.Conservation;
+
+public class WaterConservationApplicationApprovalRequest : ApplicationStoreRequestBase
+{
+    public Guid WaterConservationApplicationId { get; set; }
+    
+    public ApprovalDecision ApprovalDecision { get; set; }
+    
+    public string ApprovalNotes { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationSubmission.cs
+++ b/src/API/WesternStatesWater.WestDaat.Database/EntityFramework/WaterConservationApplicationSubmission.cs
@@ -17,6 +17,8 @@ public class WaterConservationApplicationSubmission
 
     public DateTimeOffset? RejectedDate { get; set; }
     
+    public Guid? ApprovedByUserId { get; set; }
+    
     public DateTimeOffset? RecommendedForDate { get; set; }
     
     public DateTimeOffset? RecommendedAgainstDate { get; set; }

--- a/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/031 Application Approval.sql
+++ b/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/031 Application Approval.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dbo.WaterConservationApplicationSubmissions ADD
+    ApprovedByUserId     UNIQUEIDENTIFIER NULL CONSTRAINT FK_WaterConservationApplicationSubmissions_ApprovedByUserId FOREIGN KEY REFERENCES Users (Id);

--- a/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/032 Application Reviewer FK Indexes.sql
+++ b/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/032 Application Reviewer FK Indexes.sql
@@ -1,7 +1,9 @@
-    CREATE UNIQUE INDEX IX_WaterConservationApplicationSubmissions_RecommendedByUserId
-        ON dbo.WaterConservationApplicationSubmissions (RecommendedByUserId)
-        WHERE RecommendedByUserId IS NOT NULL;
-    CREATE UNIQUE INDEX IX_WaterConservationApplicationSubmissions_ApprovedByUserId
-        ON dbo.WaterConservationApplicationSubmissions (ApprovedByUserId)
-        WHERE ApprovedByUserId IS NOT NULL;
+CREATE INDEX IX_WaterConservationApplicationSubmissions_RecommendedByUserId
+    ON dbo.WaterConservationApplicationSubmissions (RecommendedByUserId)
+    WHERE RecommendedByUserId IS NOT NULL;
+
+CREATE INDEX IX_WaterConservationApplicationSubmissions_ApprovedByUserId
+    ON dbo.WaterConservationApplicationSubmissions (ApprovedByUserId)
+    WHERE ApprovedByUserId IS NOT NULL;
+
 GO

--- a/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/032 Application Reviewer FK Indexes.sql
+++ b/src/API/WesternStatesWater.WestDaat.DbUp/Scripts/001/032 Application Reviewer FK Indexes.sql
@@ -1,0 +1,7 @@
+    CREATE UNIQUE INDEX IX_WaterConservationApplicationSubmissions_RecommendedByUserId
+        ON dbo.WaterConservationApplicationSubmissions (RecommendedByUserId)
+        WHERE RecommendedByUserId IS NOT NULL;
+    CREATE UNIQUE INDEX IX_WaterConservationApplicationSubmissions_ApprovedByUserId
+        ON dbo.WaterConservationApplicationSubmissions (ApprovedByUserId)
+        WHERE ApprovedByUserId IS NOT NULL;
+GO

--- a/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Mapping/ApiProfile.cs
@@ -258,6 +258,9 @@ namespace WesternStatesWater.WestDaat.Managers.Mapping
 
             CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationRecommendationRequest, CommonContracts.WaterConservationApplicationRecommendationRequest>()
                 .ForMember(dest => dest.RecommendedByUserId, opt => opt.Ignore());
+            
+            CreateMap<ClientContracts.Requests.Conservation.WaterConservationApplicationApprovalRequest, CommonContracts.WaterConservationApplicationApprovalRequest>()
+                .ForMember(dest => dest.ApprovedByUserId, opt => opt.Ignore());
         }
 
         public static CommonContracts.ConservationApplicationStatus EvaluateApplicationStatus(DateTimeOffset? acceptedDate, DateTimeOffset? rejectedDate)

--- a/src/DashboardUI/src/data-contracts/ApprovalDecision.ts
+++ b/src/DashboardUI/src/data-contracts/ApprovalDecision.ts
@@ -1,0 +1,11 @@
+export enum ApprovalDecision {
+  Unknown = 0,
+  Accepted = 1,
+  Rejected = 2,
+}
+
+export const ApprovalDecisionDisplayNames: { [key in ApprovalDecision]: string } = {
+  [ApprovalDecision.Unknown]: 'Unknown',
+  [ApprovalDecision.Accepted]: 'Accept',
+  [ApprovalDecision.Rejected]: 'Deny',
+};

--- a/src/DashboardUI/src/data-contracts/WaterConservationApplicationApprovalRequest.ts
+++ b/src/DashboardUI/src/data-contracts/WaterConservationApplicationApprovalRequest.ts
@@ -1,0 +1,9 @@
+import { ApplicationStoreRequestBase } from './ApplicationStoreRequestBase';
+import { ApprovalDecision } from './ApprovalDecision';
+
+export interface WaterConservationApplicationApprovalRequest extends ApplicationStoreRequestBase {
+  $type: 'WaterConservationApplicationApprovalRequest';
+  waterConservationApplicationId: string;
+  approvalDecision: ApprovalDecision;
+  approvalNotes: string;
+}


### PR DESCRIPTION
## Description

This adds the data contracts that will be needed for the funding organization's Application Review (to Accept or Deny an application) process.

The API call chain and UI layout will be added in subsequent PRs.

There's not really any testing to be done yet, outside of the `WaterConservationApplicationSubmission` database schema change script.
(Only `ApprovedByUserId` was added, `AcceptedDate` and `RejectedDate` already existed).

![26690-PR-database](https://github.com/user-attachments/assets/bdb9ef34-749d-4f00-83ce-a4ea22c9b0ac)

![26690-PR-database-2](https://github.com/user-attachments/assets/837e4e8a-1866-440d-8e1b-ba88957e1f24)

---

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] ~~Did you add tests?~~
- [x] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
