### PR TITLE
Control Locations (5b/x) - Add ApplicationAccessor method UpdateApplicationEstimate; update validation engine

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -252,9 +252,13 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
             db.ControlLocationWaterMeasurements.RemoveRange(existingControlLocation.WaterMeasurements);
 
             var newControlLocationWaterMeasurements = request.ControlLocation.WaterMeasurements.Select(measurement =>
-                DtoMapper.Map<EFWD.ControlLocationWaterMeasurement>((existingControlLocation, measurement))
+                DtoMapper.Map<EFWD.ControlLocationWaterMeasurement>(measurement)
             ).ToArray();
-            await db.ControlLocationWaterMeasurements.AddRangeAsync(newControlLocationWaterMeasurements);
+
+            foreach (var newWaterMeasurement in newControlLocationWaterMeasurements)
+            {
+                existingControlLocation.WaterMeasurements.Add(newWaterMeasurement);
+            }
 
             // update Control Location
             DtoMapper.Map(request.ControlLocation, existingControlLocation);

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -262,8 +262,8 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         else
         {
             // add new Control Location + related data
-            var requestControlLocation = DtoMapper.Map<EFWD.WaterConservationApplicationEstimateControlLocation>((existingEntity, request.ControlLocation));
-            await db.WaterConservationApplicationEstimateControlLocations.AddAsync(requestControlLocation);
+            var requestControlLocation = DtoMapper.Map<EFWD.WaterConservationApplicationEstimateControlLocation>(request.ControlLocation);
+            existingEntity.ControlLocations.Add(requestControlLocation);
         }
 
         // merge Locations:

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -78,7 +78,6 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         await using var db = _westDaatDatabaseContextFactory.Create();
 
         IQueryable<EFWD.WaterConservationApplication> applicationQuery = db.WaterConservationApplications
-            .Include(app => app.Estimate).ThenInclude(est => est.Locations)
             .Include(app => app.Submission)
             .AsNoTracking();
 

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -319,11 +319,13 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
 
         await db.SaveChangesAsync();
 
-        return new ApplicationEstimateUpdateResponse
+        var response = new ApplicationEstimateUpdateResponse
         {
             Details = DtoMapper.Map<ApplicationEstimateLocationDetails[]>(existingEntity.Locations),
             ControlLocationDetails = DtoMapper.Map<ApplicationEstimateControlLocationDetails[]>(existingEntity.ControlLocations).SingleOrDefault()
         };
+
+        return response;
     }
 
     private async Task<WaterConservationApplicationCreateResponse> CreateWaterConservationApplication(WaterConservationApplicationCreateRequest request)

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -78,6 +78,7 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
         await using var db = _westDaatDatabaseContextFactory.Create();
 
         IQueryable<EFWD.WaterConservationApplication> applicationQuery = db.WaterConservationApplications
+            .Include(app => app.Estimate).ThenInclude(est => est.Locations)
             .Include(app => app.Submission)
             .AsNoTracking();
 

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -283,12 +283,15 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
 
         // - create new entries for locations that do not already exist
         var requestLocationsToBeCreated = request.Locations
-            .Where(l => !l.WaterConservationApplicationEstimateLocationId.HasValue)
-            .Select(l => DtoMapper.Map<EFWD.WaterConservationApplicationEstimateLocation>((l, existingEntity)))
+            .Where(l => l.WaterConservationApplicationEstimateLocationId is null)
+            .Select(l => DtoMapper.Map<EFWD.WaterConservationApplicationEstimateLocation>(l))
             .ToArray();
 
         // (this also creates the WaterMeasurements for each location)
-        await db.WaterConservationApplicationEstimateLocations.AddRangeAsync(requestLocationsToBeCreated);
+        foreach (var location in requestLocationsToBeCreated)
+        {
+            existingEntity.Locations.Add(location);
+        }
 
         // - update entries for locations that remain
         var existingLocationsToBeUpdated = existingEntity.Locations

--- a/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/ApplicationAccessor.cs
@@ -251,9 +251,7 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
             // overwrite water measurements
             db.ControlLocationWaterMeasurements.RemoveRange(existingControlLocation.WaterMeasurements);
 
-            var newControlLocationWaterMeasurements = request.ControlLocation.WaterMeasurements.Select(measurement =>
-                DtoMapper.Map<EFWD.ControlLocationWaterMeasurement>(measurement)
-            ).ToArray();
+            var newControlLocationWaterMeasurements = DtoMapper.Map<EFWD.ControlLocationWaterMeasurement[]>(request.ControlLocation.WaterMeasurements);
 
             foreach (var newWaterMeasurement in newControlLocationWaterMeasurements)
             {
@@ -309,10 +307,12 @@ internal class ApplicationAccessor : AccessorBase, IApplicationAccessor
             // add new water measurements
             var matchingRequestLocation = request.Locations.Single(l => l.WaterConservationApplicationEstimateLocationId == location.Id);
 
-            var newWaterMeasurements = matchingRequestLocation.ConsumptiveUses.Select(cu =>
-                DtoMapper.Map<EFWD.LocationWaterMeasurement>((location, cu))
-            ).ToArray();
-            await db.LocationWaterMeasurements.AddRangeAsync(newWaterMeasurements);
+            var newWaterMeasurements = DtoMapper.Map<EFWD.LocationWaterMeasurement[]>(matchingRequestLocation.ConsumptiveUses);
+
+            foreach (var newWaterMeasurement in newWaterMeasurements)
+            {
+                location.WaterMeasurements.Add(newWaterMeasurement);
+            }
 
             // update the location itself
             DtoMapper.Map(matchingRequestLocation, location);

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -412,13 +412,6 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<ApplicationSubmissionFieldDetail, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source)
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
 
-            CreateMap<(EFWD.WaterConservationApplicationEstimate Estimate, ApplicationEstimateStoreControlLocationDetails ControlLocationDetails), EFWD.WaterConservationApplicationEstimateControlLocation>()
-                .ForMember(dest => dest.Id, opt => opt.Ignore())
-                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
-                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
-                .ForMember(dest => dest.PointWkt, opt => opt.MapFrom(src => src.ControlLocationDetails.PointWkt))
-                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ControlLocationDetails.WaterMeasurements));
-
             CreateMap<(EFWD.WaterConservationApplicationEstimateControlLocation ControlLocation, ApplicationEstimateStoreControlLocationWaterMeasurementsDetails WaterMeasurementDetails), EFWD.ControlLocationWaterMeasurement>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.Location, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -412,6 +412,37 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<ApplicationSubmissionFieldDetail, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source)
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
 
+            CreateMap<(EFWD.WaterConservationApplicationEstimate Estimate, ApplicationEstimateStoreControlLocationDetails ControlLocationDetails), EFWD.WaterConservationApplicationEstimateControlLocation>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
+                .ForMember(dest => dest.PointWkt, opt => opt.MapFrom(src => src.ControlLocationDetails.PointWkt))
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ControlLocationDetails.WaterMeasurements));
+
+            CreateMap<(EFWD.WaterConservationApplicationEstimateControlLocation ControlLocation, ApplicationEstimateStoreControlLocationWaterMeasurementsDetails WaterMeasurementDetails), EFWD.ControlLocationWaterMeasurement>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateControlLocationId, opt => opt.MapFrom(src => src.ControlLocation.Id))
+                .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
+                .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches));
+
+            CreateMap<(ApplicationEstimateUpdateLocationDetails LocationDetails, EFWD.WaterConservationApplicationEstimate Estimate), EFWD.WaterConservationApplicationEstimateLocation>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
+                .ForMember(dest => dest.PolygonWkt, opt => opt.MapFrom(src => src.LocationDetails.PolygonWkt))
+                .ForMember(dest => dest.DrawToolType, opt => opt.MapFrom(src => src.LocationDetails.DrawToolType))
+                .ForMember(dest => dest.PolygonAreaInAcres, opt => opt.MapFrom(src => src.LocationDetails.PolygonAreaInAcres))
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.LocationDetails.ConsumptiveUses));
+
+            CreateMap<(EFWD.WaterConservationApplicationEstimateLocation Location, ApplicationEstimateStoreLocationConsumptiveUseDetails WaterMeasurementDetails), EFWD.LocationWaterMeasurement>()
+                .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Location.Id))
+                .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
+                .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches))
+                .ForMember(dest => dest.EffectivePrecipitationInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.EffectivePrecipitationInInches))
+                .ForMember(dest => dest.NetEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.NetEtInInches));
+
+            CreateMap<ApplicationEstimateUpdateLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source);
+
+            CreateMap<ApplicationEstimateUpdateRequest, EFWD.WaterConservationApplicationEstimate>(MemberList.Source)
+                // these fields are being managed manually
+                .ForMember(dest => dest.Locations, opt => opt.Ignore())
+                .ForMember(dest => dest.ControlLocations, opt => opt.Ignore());
+
             CreateMap<EFWD.WaterConservationApplicationEstimateLocation, ApplicationEstimateLocationDetails>()
                 .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Id));
 

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -412,13 +412,6 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<ApplicationSubmissionFieldDetail, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source)
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
 
-            CreateMap<(EFWD.WaterConservationApplicationEstimateControlLocation ControlLocation, ApplicationEstimateStoreControlLocationWaterMeasurementsDetails WaterMeasurementDetails), EFWD.ControlLocationWaterMeasurement>()
-                .ForMember(dest => dest.Id, opt => opt.Ignore())
-                .ForMember(dest => dest.Location, opt => opt.Ignore())
-                .ForMember(dest => dest.WaterConservationApplicationEstimateControlLocationId, opt => opt.MapFrom(src => src.ControlLocation.Id))
-                .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
-                .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches));
-
             CreateMap<(EFWD.WaterConservationApplicationEstimateLocation Location, ApplicationEstimateStoreLocationConsumptiveUseDetails WaterMeasurementDetails), EFWD.LocationWaterMeasurement>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.Location, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -413,16 +413,23 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
 
             CreateMap<(EFWD.WaterConservationApplicationEstimate Estimate, ApplicationEstimateStoreControlLocationDetails ControlLocationDetails), EFWD.WaterConservationApplicationEstimateControlLocation>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
                 .ForMember(dest => dest.PointWkt, opt => opt.MapFrom(src => src.ControlLocationDetails.PointWkt))
                 .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ControlLocationDetails.WaterMeasurements));
 
             CreateMap<(EFWD.WaterConservationApplicationEstimateControlLocation ControlLocation, ApplicationEstimateStoreControlLocationWaterMeasurementsDetails WaterMeasurementDetails), EFWD.ControlLocationWaterMeasurement>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Location, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateControlLocationId, opt => opt.MapFrom(src => src.ControlLocation.Id))
                 .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
                 .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches));
 
             CreateMap<(ApplicationEstimateUpdateLocationDetails LocationDetails, EFWD.WaterConservationApplicationEstimate Estimate), EFWD.WaterConservationApplicationEstimateLocation>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
+                .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
                 .ForMember(dest => dest.PolygonWkt, opt => opt.MapFrom(src => src.LocationDetails.PolygonWkt))
                 .ForMember(dest => dest.DrawToolType, opt => opt.MapFrom(src => src.LocationDetails.DrawToolType))
@@ -430,18 +437,33 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.LocationDetails.ConsumptiveUses));
 
             CreateMap<(EFWD.WaterConservationApplicationEstimateLocation Location, ApplicationEstimateStoreLocationConsumptiveUseDetails WaterMeasurementDetails), EFWD.LocationWaterMeasurement>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Location, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Location.Id))
                 .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
                 .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches))
                 .ForMember(dest => dest.EffectivePrecipitationInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.EffectivePrecipitationInInches))
                 .ForMember(dest => dest.NetEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.NetEtInInches));
 
-            CreateMap<ApplicationEstimateUpdateLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source);
+            CreateMap<ApplicationEstimateUpdateLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.Ignore())
+                .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore()) // special case; this property is carried over
+                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.Ignore());
 
-            CreateMap<ApplicationEstimateUpdateRequest, EFWD.WaterConservationApplicationEstimate>(MemberList.Source)
+            CreateMap<ApplicationEstimateUpdateRequest, EFWD.WaterConservationApplicationEstimate>()
                 // these fields are being managed manually
                 .ForMember(dest => dest.Locations, opt => opt.Ignore())
-                .ForMember(dest => dest.ControlLocations, opt => opt.Ignore());
+                .ForMember(dest => dest.ControlLocations, opt => opt.Ignore())
+                // these fields should not change when updating the estimate
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Model, opt => opt.Ignore())
+                .ForMember(dest => dest.DateRangeStart, opt => opt.Ignore())
+                .ForMember(dest => dest.DateRangeEnd, opt => opt.Ignore())
+                .ForMember(dest => dest.CompensationRateDollars, opt => opt.Ignore())
+                .ForMember(dest => dest.CompensationRateUnits, opt => opt.Ignore())
+                .ForMember(dest => dest.WaterConservationApplication, opt => opt.Ignore());
 
             CreateMap<EFWD.WaterConservationApplicationEstimateLocation, ApplicationEstimateLocationDetails>()
                 .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Id));

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -443,7 +443,8 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<EFWD.WaterConservationApplication, ApplicationExistsLoadResponse>()
                 .ForMember(dest => dest.ApplicationExists, opt => opt.MapFrom(_ => true))
                 .ForMember(dest => dest.ApplicationId, opt => opt.MapFrom(src => src.Id))
-                .ForMember(dest => dest.Status, opt => opt.MapFrom(src => EvaluateApplicationStatus(src.Submission.AcceptedDate, src.Submission.RejectedDate)));
+                .ForMember(dest => dest.Status, opt => opt.MapFrom(src => EvaluateApplicationStatus(src.Submission.AcceptedDate, src.Submission.RejectedDate)))
+                .ForMember(dest => dest.EstimateLocationIds, opt => opt.MapFrom(src => src.Estimate.Locations.Select(loc => loc.Id).ToArray()));
         }
 
         // duplicated in other ApiProfile.cs

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -426,16 +426,6 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
                 .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches));
 
-            CreateMap<(ApplicationEstimateUpdateLocationDetails LocationDetails, EFWD.WaterConservationApplicationEstimate Estimate), EFWD.WaterConservationApplicationEstimateLocation>()
-                .ForMember(dest => dest.Id, opt => opt.Ignore())
-                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
-                .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore())
-                .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.MapFrom(src => src.Estimate.Id))
-                .ForMember(dest => dest.PolygonWkt, opt => opt.MapFrom(src => src.LocationDetails.PolygonWkt))
-                .ForMember(dest => dest.DrawToolType, opt => opt.MapFrom(src => src.LocationDetails.DrawToolType))
-                .ForMember(dest => dest.PolygonAreaInAcres, opt => opt.MapFrom(src => src.LocationDetails.PolygonAreaInAcres))
-                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.LocationDetails.ConsumptiveUses));
-
             CreateMap<(EFWD.WaterConservationApplicationEstimateLocation Location, ApplicationEstimateStoreLocationConsumptiveUseDetails WaterMeasurementDetails), EFWD.LocationWaterMeasurement>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.Location, opt => opt.Ignore())
@@ -446,11 +436,11 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
                 .ForMember(dest => dest.NetEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.NetEtInInches));
 
             CreateMap<ApplicationEstimateUpdateLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>()
+                .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ConsumptiveUses))
                 .ForMember(dest => dest.Id, opt => opt.Ignore())
                 .ForMember(dest => dest.WaterConservationApplicationEstimateId, opt => opt.Ignore())
                 .ForMember(dest => dest.AdditionalDetails, opt => opt.Ignore()) // special case; this property is carried over
-                .ForMember(dest => dest.Estimate, opt => opt.Ignore())
-                .ForMember(dest => dest.WaterMeasurements, opt => opt.Ignore());
+                .ForMember(dest => dest.Estimate, opt => opt.Ignore());
 
             CreateMap<ApplicationEstimateUpdateRequest, EFWD.WaterConservationApplicationEstimate>()
                 // these fields are being managed manually

--- a/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
+++ b/src/API/WesternStatesWater.WestDaat.Accessors/Mapping/ApiProfile.cs
@@ -412,15 +412,6 @@ namespace WesternStatesWater.WestDaat.Accessors.Mapping
             CreateMap<ApplicationSubmissionFieldDetail, EFWD.WaterConservationApplicationEstimateLocation>(MemberList.Source)
                 .ForSourceMember(src => src.WaterConservationApplicationEstimateLocationId, opt => opt.DoNotValidate());
 
-            CreateMap<(EFWD.WaterConservationApplicationEstimateLocation Location, ApplicationEstimateStoreLocationConsumptiveUseDetails WaterMeasurementDetails), EFWD.LocationWaterMeasurement>()
-                .ForMember(dest => dest.Id, opt => opt.Ignore())
-                .ForMember(dest => dest.Location, opt => opt.Ignore())
-                .ForMember(dest => dest.WaterConservationApplicationEstimateLocationId, opt => opt.MapFrom(src => src.Location.Id))
-                .ForMember(dest => dest.Year, opt => opt.MapFrom(src => src.WaterMeasurementDetails.Year))
-                .ForMember(dest => dest.TotalEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.TotalEtInInches))
-                .ForMember(dest => dest.EffectivePrecipitationInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.EffectivePrecipitationInInches))
-                .ForMember(dest => dest.NetEtInInches, opt => opt.MapFrom(src => src.WaterMeasurementDetails.NetEtInInches));
-
             CreateMap<ApplicationEstimateUpdateLocationDetails, EFWD.WaterConservationApplicationEstimateLocation>()
                 .ForMember(dest => dest.WaterMeasurements, opt => opt.MapFrom(src => src.ConsumptiveUses))
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateLocationDetails.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateLocationDetails.cs
@@ -1,0 +1,14 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateUpdateLocationDetails
+{
+    required public Guid? WaterConservationApplicationEstimateLocationId { get; set; }
+
+    required public string PolygonWkt { get; set; }
+
+    required public DrawToolType DrawToolType { get; set; }
+
+    required public double PolygonAreaInAcres { get; set; }
+
+    required public ApplicationEstimateStoreLocationConsumptiveUseDetails[] ConsumptiveUses { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateRequest.cs
@@ -1,0 +1,16 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateUpdateRequest : ApplicationStoreRequestBase
+{
+    required public Guid WaterConservationApplicationId { get; set; }
+
+    required public int EstimatedCompensationDollars { get; set; }
+
+    required public double CumulativeTotalEtInAcreFeet { get; set; }
+
+    required public double? CumulativeNetEtInAcreFeet { get; set; } = null!;
+
+    required public ApplicationEstimateUpdateLocationDetails[] Locations { get; set; }
+
+    required public ApplicationEstimateStoreControlLocationDetails ControlLocation { get; set; } = null!;
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationEstimateUpdateResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace WesternStatesWater.WestDaat.Common.DataContracts;
+
+public class ApplicationEstimateUpdateResponse : ApplicationStoreResponseBase
+{
+    public ApplicationEstimateLocationDetails[] Details { get; set; }
+
+    public ApplicationEstimateControlLocationDetails ControlLocationDetails { get; set; }
+}

--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationExistsLoadResponse.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/ApplicationExistsLoadResponse.cs
@@ -14,5 +14,7 @@ public class ApplicationExistsLoadResponse : ApplicationLoadResponseBase
 
     public string FundingOrganizationName { get; set; } = null!;
 
+    public Guid[] EstimateLocationIds { get; set; } = [];
+
     public ConservationApplicationStatus? Status { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/MapPolygon.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/MapPolygon.cs
@@ -2,6 +2,8 @@
 
 public class MapPolygon
 {
+    public Guid? WaterConservationApplicationEstimateLocationId { get; set; } = null!;
+
     /// <summary>
     /// Polygon in "Well-known text" (WKT) format.
     /// <br />

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequest.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequest.cs
@@ -8,5 +8,5 @@ public class ReviewerEstimateConsumptiveUseRequest : ApplicationStoreRequestBase
 
     public MapPoint ControlLocation { get; set; }
 
-    public bool OverwriteEstimate { get; set; }
+    public bool UpdateEstimate { get; set; }
 }

--- a/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
@@ -268,9 +268,9 @@ internal class ValidationEngine : IValidationEngine
 
         // if user provides an id in an attempt to update an existing location, then a location must already exist with that id
         var requestLocationIds = request.Polygons
-            .Select(location => location.WaterConservationApplicationEstimateLocationId)
-            .Where(id => id != null)
-            .Select(id => id.Value);
+            .Where(location => location.WaterConservationApplicationEstimateLocationId.HasValue)
+            .Select(location => location.WaterConservationApplicationEstimateLocationId.Value);
+
         var databaseLocationIds = applicationExistsResponse.EstimateLocationIds;
 
         var requestLocationIdsNotInDatabase = requestLocationIds.Except(databaseLocationIds);

--- a/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/ValidationEngine.cs
@@ -169,7 +169,7 @@ internal class ValidationEngine : IValidationEngine
         return request switch
         {
             ApplicantEstimateConsumptiveUseRequest req => await ValidateApplicantEstimateConsumptiveUseRequest(req, context),
-            ReviewerEstimateConsumptiveUseRequest req => await ValidateEstimateConsumptiveUseReviewerRequest(req, context),
+            ReviewerEstimateConsumptiveUseRequest req => await ValidateReviewerEstimateConsumptiveUseRequest(req, context),
             WaterConservationApplicationCreateRequest req => await ValidateWaterConservationApplicationCreateRequest(req, context),
             WaterConservationApplicationSubmissionRequest req => await ValidateWaterConservationApplicationSubmissionRequest(req, context),
             WaterConservationApplicationSubmissionUpdateRequest req => await ValidateWaterConservationApplicationSubmissionUpdateRequest(req, context),
@@ -236,7 +236,7 @@ internal class ValidationEngine : IValidationEngine
         return null;
     }
 
-    private async Task<ErrorBase> ValidateEstimateConsumptiveUseReviewerRequest(ReviewerEstimateConsumptiveUseRequest request, ContextBase context)
+    private async Task<ErrorBase> ValidateReviewerEstimateConsumptiveUseRequest(ReviewerEstimateConsumptiveUseRequest request, ContextBase context)
     {
         // user must be logged in
         var userContext = _contextUtility.GetRequiredContext<UserContext>();

--- a/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
+++ b/src/API/WesternStatesWater.WestDaat.Managers/Handlers/Conservation/ReviewerEstimateConsumptiveUseRequestHandler.cs
@@ -51,7 +51,7 @@ public class ReviewerEstimateConsumptiveUseRequestHandler : IRequestHandler<Revi
         var estimateConservationPaymentRequest = DtoMapper.Map<EstimateConservationPaymentRequest>((originalEstimate, evapotranspirationResponse));
         var estimateConservationPaymentResponse = (EstimateConservationPaymentResponse)await CalculationEngine.Calculate(estimateConservationPaymentRequest);
 
-        if (request.OverwriteEstimate)
+        if (request.UpdateEstimate)
         {
             // store estimate
             var storeEstimateRequest = DtoMapper.Map<ApplicationEstimateStoreRequest>((

--- a/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
@@ -295,10 +295,12 @@ public class ApplicationAccessorTests : AccessorTestBase
             CumulativeNetEtInAcreFeet = 800,
             EstimatedCompensationDollars = 5000,
 
-            // control location will be updated, water measurements will be overwritten
+            // control location will be updated
             ControlLocation = new ApplicationEstimateStoreControlLocationDetails
             {
                 PointWkt = pointWkt,
+                // if control location did not already exist, new water measurements will be created
+                // if control location did exist, existing water measurements will be deleted and new water measurements will be created
                 WaterMeasurements = [
                     new ApplicationEstimateStoreControlLocationWaterMeasurementsDetails
                     {
@@ -308,7 +310,11 @@ public class ApplicationAccessorTests : AccessorTestBase
                 ]
             },
 
-            // locations will be created/deleted/updated, water measurements will be created/deleted (not updated)
+            // locations will be created/deleted/updated
+            // water measurements are conditional:
+            // if a location is deleted, its water measurements will be deleted too
+            // if a location is created, its water measurements will be created too
+            // if a location is updated, its water measurements will be deleted and new water measurements will be created
             Locations =
             [
                 // update location

--- a/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
@@ -252,4 +252,181 @@ public class ApplicationAccessorTests : AccessorTestBase
         application.WaterRightNativeId.Should().Be(request.WaterRightNativeId);
         application.ApplicationDisplayId.Should().Be(request.ApplicationDisplayId);
     }
+
+    [DataTestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task Store_UpdateApplicationEstimate_Success(bool shouldInitializeControlLocation)
+    {
+        // Arrange
+        var user = new UserFaker().Generate();
+        var organization = new OrganizationFaker().Generate();
+        var application = new WaterConservationApplicationFaker(user, organization).Generate();
+        await _westDaatDb.WaterConservationApplications.AddAsync(application);
+
+        var estimate = new WaterConservationApplicationEstimateFaker(application).Generate();
+        var locations = new WaterConservationApplicationEstimateLocationFaker(estimate).Generate(2);
+        var locationWaterMeasurements = locations.Select(location =>
+            new LocationWaterMeasurementFaker(location).Generate(5)
+        ).SelectMany(waterMeasurements => waterMeasurements)
+        .ToArray();
+        await _westDaatDb.LocationWaterMeasurements.AddRangeAsync(locationWaterMeasurements);
+
+        WaterConservationApplicationEstimateControlLocation controlLocation = null;
+        if (shouldInitializeControlLocation)
+        {
+            controlLocation = new WaterConservationApplicationEstimateControlLocationFaker(estimate).Generate();
+            var controlLocationWaterMeasurements = new ControlLocationWaterMeasurementFaker(controlLocation).Generate(5);
+            await _westDaatDb.ControlLocationWaterMeasurements.AddRangeAsync(controlLocationWaterMeasurements);
+        }
+
+        await _westDaatDb.SaveChangesAsync();
+
+        string pointWkt = "POINT (5 5)",
+               polygonWkt = "POLYGON ((1 1), (3 3), (5 5))";
+
+        var request = new ApplicationEstimateUpdateRequest
+        {
+            // estimate data will be updated
+            WaterConservationApplicationId = application.Id,
+            CumulativeTotalEtInAcreFeet = 1000,
+            CumulativeNetEtInAcreFeet = 800,
+            EstimatedCompensationDollars = 5000,
+
+            // control location will be updated, water measurements will be overwritten
+            ControlLocation = new ApplicationEstimateStoreControlLocationDetails
+            {
+                PointWkt = pointWkt,
+                WaterMeasurements = [
+                    new ApplicationEstimateStoreControlLocationWaterMeasurementsDetails
+                    {
+                        Year = 2025,
+                        TotalEtInInches = 5
+                    }
+                ]
+            },
+
+            // locations will be created/deleted/updated, water measurements will be created/deleted (not updated)
+            Locations =
+            [
+                // update location
+                new ApplicationEstimateUpdateLocationDetails
+                {
+                    WaterConservationApplicationEstimateLocationId = locations[0].Id,
+                    PolygonWkt = polygonWkt,
+                    DrawToolType = DrawToolType.Freeform,
+                    PolygonAreaInAcres = 1,
+                    ConsumptiveUses =
+                    [
+                        new ApplicationEstimateStoreLocationConsumptiveUseDetails
+                        {
+                            Year = 2025,
+                            TotalEtInInches = 5,
+                            EffectivePrecipitationInInches = 1,
+                            NetEtInInches = 4
+                        }
+                    ]
+                },
+                // create new location
+                new ApplicationEstimateUpdateLocationDetails
+                {
+                    WaterConservationApplicationEstimateLocationId = null,
+                    PolygonWkt = polygonWkt,
+                    DrawToolType = DrawToolType.Rectangle,
+                    PolygonAreaInAcres = 2,
+                    ConsumptiveUses =
+                    [
+                        new ApplicationEstimateStoreLocationConsumptiveUseDetails
+                        {
+                            Year = 2025,
+                            TotalEtInInches = 10,
+                            EffectivePrecipitationInInches = 2,
+                            NetEtInInches = 8
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var response = (ApplicationEstimateUpdateResponse)await _accessor.Store(request);
+
+        // Assert
+        // validate response object
+        response.Should().NotBeNull();
+        response.Details.Should().NotBeNullOrEmpty();
+        response.Details.Length.Should().Be(2);
+
+        foreach (var location in response.Details)
+        {
+            location.WaterConservationApplicationEstimateLocationId.Should().NotBe(Guid.Empty);
+            location.PolygonWkt.Should().Be(polygonWkt);
+        }
+
+        response.ControlLocationDetails.Should().NotBeNull();
+        response.ControlLocationDetails.WaterConservationApplicationEstimateControlLocationId.Should().NotBe(Guid.Empty);
+        response.ControlLocationDetails.PointWkt.Should().Be(pointWkt);
+
+        // validate database entries
+        var dbEstimate = await _westDaatDb.WaterConservationApplicationEstimates
+            .Include(est => est.Locations).ThenInclude(location => location.WaterMeasurements)
+            .Include(est => est.ControlLocations).ThenInclude(clocation => clocation.WaterMeasurements)
+            .SingleOrDefaultAsync(est => est.Id == estimate.Id);
+
+        // estiamte
+        dbEstimate.Should().NotBeNull();
+        dbEstimate.CumulativeTotalEtInAcreFeet.Should().Be(request.CumulativeTotalEtInAcreFeet);
+        dbEstimate.CumulativeNetEtInAcreFeet.Should().Be(request.CumulativeNetEtInAcreFeet);
+        dbEstimate.EstimatedCompensationDollars.Should().Be(request.EstimatedCompensationDollars);
+
+        // locations
+        dbEstimate.Locations.Should().HaveCount(request.Locations.Length);
+
+        var unreferencedLocationWasDeleted = dbEstimate.Locations.Any(location => location.Id == locations[1].Id);
+        unreferencedLocationWasDeleted.Should().BeTrue();
+
+        var updatedLocation = dbEstimate.Locations.Single(l => l.Id == locations[0].Id);
+        updatedLocation.PolygonWkt.Should().Be(polygonWkt);
+        updatedLocation.DrawToolType.Should().Be(request.Locations[0].DrawToolType);
+        updatedLocation.PolygonAreaInAcres.Should().Be(request.Locations[0].PolygonAreaInAcres);
+
+        var newLocation = dbEstimate.Locations.Single(l => l.Id != locations[0].Id);
+        newLocation.PolygonWkt.Should().Be(polygonWkt);
+        newLocation.DrawToolType.Should().Be(request.Locations[1].DrawToolType);
+        newLocation.PolygonAreaInAcres.Should().Be(request.Locations[1].PolygonAreaInAcres);
+
+        // location water measurements
+        updatedLocation.WaterMeasurements.Should().HaveCount(1);
+
+        var measurement1 = updatedLocation.WaterMeasurements.Single();
+        measurement1.Year.Should().Be(request.Locations[0].ConsumptiveUses[0].Year);
+        measurement1.TotalEtInInches.Should().Be(request.Locations[0].ConsumptiveUses[0].TotalEtInInches);
+        measurement1.EffectivePrecipitationInInches.Should().Be(request.Locations[0].ConsumptiveUses[0].EffectivePrecipitationInInches);
+        measurement1.NetEtInInches.Should().Be(request.Locations[0].ConsumptiveUses[0].NetEtInInches);
+
+        var measurement2 = newLocation.WaterMeasurements.Single();
+        measurement2.Year.Should().Be(request.Locations[1].ConsumptiveUses[0].Year);
+        measurement2.TotalEtInInches.Should().Be(request.Locations[1].ConsumptiveUses[0].TotalEtInInches);
+        measurement2.EffectivePrecipitationInInches.Should().Be(request.Locations[1].ConsumptiveUses[0].EffectivePrecipitationInInches);
+        measurement2.NetEtInInches.Should().Be(request.Locations[1].ConsumptiveUses[0].NetEtInInches);
+
+        // control location
+        var dbControlLocation = dbEstimate.ControlLocations.Single();
+        dbControlLocation.PointWkt.Should().Be(request.ControlLocation.PointWkt);
+
+        if (shouldInitializeControlLocation)
+        {
+            dbControlLocation.Id.Should().Be(controlLocation.Id);
+        }
+        else
+        {
+            controlLocation.Should().BeNull();
+            dbControlLocation.Id.Should().NotBe(Guid.Empty);
+        }
+
+        // control location water measurements
+        var clMeasurement = dbControlLocation.WaterMeasurements.Single();
+        clMeasurement.Year.Should().Be(request.ControlLocation.WaterMeasurements[0].Year);
+        clMeasurement.TotalEtInInches.Should().Be(request.ControlLocation.WaterMeasurements[0].TotalEtInInches);
+    }
 }

--- a/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
@@ -382,7 +382,7 @@ public class ApplicationAccessorTests : AccessorTestBase
         // locations
         dbEstimate.Locations.Should().HaveCount(request.Locations.Length);
 
-        var unreferencedLocationWasDeleted = dbEstimate.Locations.Any(location => location.Id == locations[1].Id);
+        var unreferencedLocationWasDeleted = dbEstimate.Locations.All(location => location.Id != locations[1].Id);
         unreferencedLocationWasDeleted.Should().BeTrue();
 
         var updatedLocation = dbEstimate.Locations.Single(l => l.Id == locations[0].Id);
@@ -391,6 +391,7 @@ public class ApplicationAccessorTests : AccessorTestBase
         updatedLocation.PolygonAreaInAcres.Should().Be(request.Locations[0].PolygonAreaInAcres);
 
         var newLocation = dbEstimate.Locations.Single(l => l.Id != locations[0].Id);
+        newLocation.Id.Should().NotBe(locations[1].Id); // location 1 was deleted; just sanity-checking that it wasn't accidentally updated
         newLocation.PolygonWkt.Should().Be(polygonWkt);
         newLocation.DrawToolType.Should().Be(request.Locations[1].DrawToolType);
         newLocation.PolygonAreaInAcres.Should().Be(request.Locations[1].PolygonAreaInAcres);

--- a/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.AccessorTests/ApplicationAccessorTests.cs
@@ -54,6 +54,7 @@ public class ApplicationAccessorTests : AccessorTestBase
         response.ApplicationExists.Should().BeTrue();
         response.ApplicationId.Should().Be(application.Id);
         response.ApplicationDisplayId.Should().Be(application.ApplicationDisplayId);
+        response.EstimateLocationIds.Should().BeEmpty();
     }
 
     [TestMethod]
@@ -83,6 +84,7 @@ public class ApplicationAccessorTests : AccessorTestBase
         response.ApplicationExists.Should().BeFalse();
         response.ApplicationId.Should().BeNull();
         response.ApplicationDisplayId.Should().BeNull();
+        response.EstimateLocationIds.Should().BeEmpty();
     }
 
     [TestMethod]
@@ -109,6 +111,7 @@ public class ApplicationAccessorTests : AccessorTestBase
         response.ApplicationExists.Should().BeFalse();
         response.ApplicationId.Should().BeNull();
         response.ApplicationDisplayId.Should().BeNull();
+        response.EstimateLocationIds.Should().BeEmpty();
     }
 
     [DataTestMethod]
@@ -137,6 +140,13 @@ public class ApplicationAccessorTests : AccessorTestBase
             application = applicationFaker.Generate();
 
             await _westDaatDb.WaterConservationApplications.AddAsync(application);
+
+            var estimate = new WaterConservationApplicationEstimateFaker(application).Generate();
+            await _westDaatDb.WaterConservationApplicationEstimates.AddAsync(estimate);
+
+            var locations = new WaterConservationApplicationEstimateLocationFaker(estimate).Generate(3);
+            await _westDaatDb.WaterConservationApplicationEstimateLocations.AddRangeAsync(locations);
+
             await _westDaatDb.SaveChangesAsync();
         }
 
@@ -158,11 +168,13 @@ public class ApplicationAccessorTests : AccessorTestBase
         {
             response.ApplicantUserId.Should().Be(application.ApplicantUserId);
             response.FundingOrganizationId.Should().Be(application.FundingOrganizationId);
+            response.EstimateLocationIds.Should().BeEquivalentTo(application.Estimate.Locations.Select(loc => loc.Id).ToArray());
         }
         else
         {
             response.ApplicantUserId.Should().BeNull();
             response.FundingOrganizationId.Should().BeNull();
+            response.EstimateLocationIds.Should().BeEmpty();
         }
     }
 

--- a/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
+++ b/src/API/WesternStatesWater.WestDaat.Tests.IntegrationTests/Conservation/ApplicationIntegrationTests.cs
@@ -803,7 +803,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
             var request = new ReviewerEstimateConsumptiveUseRequest
             {
                 WaterConservationApplicationId = application.Id,
-                OverwriteEstimate = shouldOverwriteApplicantsEstimate,
+                UpdateEstimate = shouldOverwriteApplicantsEstimate,
                 Polygons =
                 [
                     new CLI.MapPolygon
@@ -1004,7 +1004,7 @@ public class ApplicationIntegrationTests : IntegrationTestBase
         var request = new ReviewerEstimateConsumptiveUseRequest
         {
             WaterConservationApplicationId = application.Id,
-            OverwriteEstimate = false,
+            UpdateEstimate = false,
             Polygons =
             [
                 new CLI.MapPolygon


### PR DESCRIPTION
Pull Request Checklist

- [ ] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
This is the first of a few PRs targeting `Ethan/26692-control-locations-5` with the goal of improving the base PR.

This PR implements the new method `ApplicationAccessor.UpdateApplicationEstimate` and adds new unit tests to verify every aspect of its functionality.

This PR also updates the `ValidationEngine` to address the following scenario:
* if the technical reviewer attempts to update an `EstimateLocation` on an `Estimate` for which no `EstimateLocation` has a matching Id, then the `ValidationEngine` should return a "Not Found" error.

Also added an integration test to verify the update to the ValidationEngine works as expected.

**all tests passing** as of 20 commits

## Next up
* PR 5c: integrate this new accessor method with the `ReviewerEstimateConsumptiveUse` call chain
* PR 5d: clean up the call chain; undo changes that are no longer needed. remove unused properties/fields/mappings etc.