### PR TITLE
Fix Reviewer EstimateConsumptiveUse Bad Request

### DIFF
--- a/src/DashboardUI/src/contexts/ConservationApplicationState.test.ts
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.test.ts
@@ -20,7 +20,7 @@ import { ReviewStepStatus } from '../data-contracts/ReviewStepStatus';
 import { ReviewStepType } from '../data-contracts/ReviewStepType';
 
 const shouldBeAbleToPerformConsumptiveUseEstimate = (state: ConservationApplicationState, expected: boolean): void => {
-  expect(state.canEstimateConsumptiveUse).toEqual(expected);
+  expect(state.canApplicantEstimateConsumptiveUse).toEqual(expected);
 };
 
 const shouldBeAbleToContinueToApplication = (state: ConservationApplicationState, expected: boolean): void => {

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.test.ts
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.test.ts
@@ -11,7 +11,7 @@ import {
   ReviewerConsumptiveUseEstimatedAction,
   ReviewerMapDataUpdatedAction,
 } from './ConservationApplicationState';
-import { MapSelectionPolygonData, PartialPolygonData } from '../data-contracts/CombinedPolygonData';
+import { MapSelectionPolygonData } from '../data-contracts/CombinedPolygonData';
 import { ApplicationDetails } from '../data-contracts/ApplicationDetails';
 import { applicationDetailsMock } from '../mocks/ApplicationDetails.mock';
 import { ApplicationReviewNote } from '../data-contracts/ApplicationReviewNote';
@@ -19,7 +19,10 @@ import { DrawToolType } from '../data-contracts/DrawToolType';
 import { ReviewStepStatus } from '../data-contracts/ReviewStepStatus';
 import { ReviewStepType } from '../data-contracts/ReviewStepType';
 
-const shouldBeAbleToPerformConsumptiveUseEstimate = (state: ConservationApplicationState, expected: boolean): void => {
+const shouldApplicantBeAbleToPerformConsumptiveUseEstimate = (
+  state: ConservationApplicationState,
+  expected: boolean,
+): void => {
   expect(state.canApplicantEstimateConsumptiveUse).toEqual(expected);
 };
 
@@ -137,7 +140,7 @@ describe('ConservationApplicationState reducer', () => {
     // Assert
     expect(newState.conservationApplication.waterRightNativeId).toEqual('mock-water-right-native-id');
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -164,7 +167,7 @@ describe('ConservationApplicationState reducer', () => {
     expect(newState.conservationApplication.dateRangeEnd).toEqual(new Date(2025, 11, 31));
     expect(newState.conservationApplication.compensationRateModel).toEqual('Mock Compensation Rate Model');
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -185,7 +188,7 @@ describe('ConservationApplicationState reducer', () => {
 
     expect(newState.isCreatingApplication).toBe(true);
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -215,7 +218,7 @@ describe('ConservationApplicationState reducer', () => {
     expect(newState.conservationApplication.estimateLocations[0].acreage).toEqual(1);
     expect(newState.conservationApplication.doPolygonsOverlap).toEqual(true);
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -234,7 +237,7 @@ describe('ConservationApplicationState reducer', () => {
     expect(newState.conservationApplication.desiredCompensationDollars).toEqual(100);
     expect(newState.conservationApplication.desiredCompensationUnits).toEqual(CompensationRateUnits.AcreFeet);
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -291,7 +294,7 @@ describe('ConservationApplicationState reducer', () => {
     expect(newState.conservationApplication.estimateLocations[0].datapoints!.length).toEqual(1);
     expect(newState.conservationApplication.estimateLocations[0].fieldName).toEqual('Field 1');
 
-    shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+    shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     shouldBeAbleToContinueToApplication(newState, false);
   });
 
@@ -400,7 +403,7 @@ describe('ConservationApplicationState reducer', () => {
       // Arrange
       // Act
       // Assert
-      shouldBeAbleToPerformConsumptiveUseEstimate(state, false);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(state, false);
     });
 
     it('estimate consumptive use should be disabled when more than the maximum number of polygons have been selected', () => {
@@ -448,7 +451,7 @@ describe('ConservationApplicationState reducer', () => {
       });
 
       // Assert
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
     });
 
     it('estimate consumptive use should be enabled when at least one map polygon is present', () => {
@@ -496,7 +499,7 @@ describe('ConservationApplicationState reducer', () => {
       });
 
       // Assert
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, true);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, true);
     });
 
     it('estimate consumptive use should be enabled or disabled depending on the sidebar inputs', () => {
@@ -544,7 +547,7 @@ describe('ConservationApplicationState reducer', () => {
 
       // Act / Assert
       // estimation form has no data
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, true);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, true);
 
       // estimation form has partial data
       newState = reducer(newState, {
@@ -554,7 +557,7 @@ describe('ConservationApplicationState reducer', () => {
           desiredCompensationUnits: undefined,
         },
       });
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
 
       newState = reducer(newState, {
         type: 'ESTIMATION_FORM_UPDATED',
@@ -563,7 +566,7 @@ describe('ConservationApplicationState reducer', () => {
           desiredCompensationUnits: CompensationRateUnits.AcreFeet,
         },
       });
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, false);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, false);
 
       // estimation form has all data
       newState = reducer(newState, {
@@ -573,7 +576,7 @@ describe('ConservationApplicationState reducer', () => {
           desiredCompensationUnits: CompensationRateUnits.AcreFeet,
         },
       });
-      shouldBeAbleToPerformConsumptiveUseEstimate(newState, true);
+      shouldApplicantBeAbleToPerformConsumptiveUseEstimate(newState, true);
     });
 
     it('continuing to application should be disabled when no data is present', () => {

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -64,7 +64,8 @@ export interface ConservationApplicationState {
   loadFundingOrganizationErrored: boolean;
   isLoadingReviewerConsumptiveUseEstimate: boolean;
   reviewerConsumptiveUseEstimateHasErrored: boolean;
-  canEstimateConsumptiveUse: boolean;
+  canApplicantEstimateConsumptiveUse: boolean;
+  canReviewerEstimateConsumptiveUse: boolean;
   canContinueToApplication: boolean;
 }
 
@@ -117,7 +118,8 @@ export const defaultState = (): ConservationApplicationState => ({
   loadFundingOrganizationErrored: false,
   isLoadingReviewerConsumptiveUseEstimate: false,
   reviewerConsumptiveUseEstimateHasErrored: false,
-  canEstimateConsumptiveUse: false,
+  canApplicantEstimateConsumptiveUse: false,
+  canReviewerEstimateConsumptiveUse: false,
   canContinueToApplication: false,
 });
 
@@ -331,6 +333,7 @@ export const reducer = (
 
 // Given an action and the current state, return the new state
 const reduce = (draftState: ConservationApplicationState, action: ApplicationAction): ConservationApplicationState => {
+  console.log('performing action', action);
   switch (action.type) {
     case 'DASHBOARD_APPLICATIONS_LOADED':
       return onDashboardApplicationsLoaded(draftState, action);
@@ -438,7 +441,7 @@ const onEstimationToolPageLoaded = (
 ): ConservationApplicationState => {
   draftState.conservationApplication.waterRightNativeId = payload.waterRightNativeId;
 
-  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
 
   return draftState;
 };
@@ -465,7 +468,7 @@ const onFundingOrganizationLoaded = (
   draftState.isLoadingFundingOrganization = false;
   draftState.loadFundingOrganizationErrored = false;
 
-  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
 
   return draftState;
 };
@@ -486,7 +489,7 @@ const onApplicationCreated = (
 
   draftState.isCreatingApplication = true;
 
-  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
 
   return draftState;
 };
@@ -499,7 +502,7 @@ const onMapPolygonsUpdated = (
   draftState.conservationApplication.doPolygonsOverlap = payload.doPolygonsOverlap;
 
   resetConsumptiveUseEstimation(draftState);
-  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
   updatePolygonAcreageSum(draftState);
   computeCombinedPolygonData(draftState);
   resetApplicationFormLocationDetails(draftState);
@@ -615,7 +618,7 @@ const onReviewerMapPolygonsUpdated = (
   // side effects
   resetConsumptiveUseEstimation(draftState);
   updatePolygonAcreageSum(draftState);
-  checkCanReviewerEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
 
   return draftState;
 };
@@ -630,7 +633,7 @@ const onEstimationFormUpdated = (
   application.desiredCompensationUnits = payload.desiredCompensationUnits;
 
   resetConsumptiveUseEstimation(draftState);
-  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanEstimateConsumptiveUse(draftState);
 
   return draftState;
 };
@@ -909,13 +912,18 @@ const onApplicationLoadErrored = (draftState: ConservationApplicationState): Con
   return draftState;
 };
 
+const checkCanEstimateConsumptiveUse = (draftState: ConservationApplicationState): void => {
+  checkCanApplicantEstimateConsumptiveUse(draftState);
+  checkCanReviewerEstimateConsumptiveUse(draftState);
+};
+
 const checkCanApplicantEstimateConsumptiveUse = (draftState: ConservationApplicationState): void => {
   const app = draftState.conservationApplication;
 
   const dollarsHasValue = !!app.desiredCompensationDollars;
   const unitsHasValue = !!app.desiredCompensationUnits;
 
-  draftState.canEstimateConsumptiveUse =
+  draftState.canApplicantEstimateConsumptiveUse =
     !!app.waterConservationApplicationId &&
     !!app.waterRightNativeId &&
     !!app.openEtModelName &&
@@ -933,7 +941,7 @@ const checkCanApplicantEstimateConsumptiveUse = (draftState: ConservationApplica
 const checkCanReviewerEstimateConsumptiveUse = (draftState: ConservationApplicationState): void => {
   const app = draftState.conservationApplication;
 
-  draftState.canEstimateConsumptiveUse =
+  draftState.canReviewerEstimateConsumptiveUse =
     !!app.waterConservationApplicationId &&
     !!app.estimateLocations &&
     app.estimateLocations.length > 0 &&

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -948,7 +948,7 @@ const checkCanReviewerEstimateConsumptiveUse = (draftState: ConservationApplicat
     app.estimateLocations.length <= conservationApplicationMaxPolygonCount &&
     app.estimateLocations.every((p) => p.acreage! <= conservationApplicationMaxPolygonAcreage) &&
     !app.doPolygonsOverlap &&
-    !!app.controlLocation &&
+    !!app.controlLocation?.pointWkt &&
     !app.doesControlLocationOverlapWithPolygons;
 };
 

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -333,7 +333,6 @@ export const reducer = (
 
 // Given an action and the current state, return the new state
 const reduce = (draftState: ConservationApplicationState, action: ApplicationAction): ConservationApplicationState => {
-  console.log('performing action', action);
   switch (action.type) {
     case 'DASHBOARD_APPLICATIONS_LOADED':
       return onDashboardApplicationsLoaded(draftState, action);

--- a/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolMap.tsx
+++ b/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolMap.tsx
@@ -136,7 +136,7 @@ export function EstimationToolMap(props: EstimationToolMapProps) {
     setUserDrawnPolygonData(polygons);
   };
 
-  const estimateButtonEnabled = state.canEstimateConsumptiveUse && !props.isLoadingConsumptiveUseEstimate;
+  const estimateButtonEnabled = state.canApplicantEstimateConsumptiveUse && !props.isLoadingConsumptiveUseEstimate;
 
   return (
     <div className="flex-grow-1 position-relative">

--- a/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
+++ b/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
@@ -198,7 +198,7 @@ function ReviewMap(props: ReviewMapProps) {
     });
   };
 
-  const estimateButtonEnabled = state.canEstimateConsumptiveUse && !props.isLoadingConsumptiveUseEstimate;
+  const estimateButtonEnabled = state.canReviewerEstimateConsumptiveUse && !props.isLoadingConsumptiveUseEstimate;
 
   const allLabelFeatures: Feature<Point, GeoJsonProperties>[] = useMemo(() => {
     return userDrawnPolygonLabelFeatures.concat(controlLocationLabelFeature ?? []);


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Split "can estimate consumptive use" check into two separate checks - one for applicant, one for reviewer - and updated references. Updated tests to reflect this change.

Fixed issue with validating the reviewer's control location existed (it checked that the object itself exists, when it needed to check that the object's `pointWkt` field existed)

## Appearance
demo video - estimate button is disabled on page load. estimate button disabled attribute updates correctly when you add / remove the control location.

https://github.com/user-attachments/assets/b95bd76e-0f01-4961-be2e-1d09b65ea82e

