### PR TITLE
Estimate Consumptive Use - Fix issue where calculation engine does not track polygon id

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPolygon.cs
+++ b/src/API/WesternStatesWater.WestDaat.Common/DataContracts/MapPolygon.cs
@@ -2,6 +2,8 @@
 
 public class MapPolygon
 {
+    public Guid? WaterConservationApplicationEstimateLocationId { get; set; } = null!;
+
     /// <summary>
     /// Polygon in "Well-known text" (WKT) format.
     /// <br />

--- a/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
+++ b/src/API/WesternStatesWater.WestDaat.Engines/CalculationEngine.cs
@@ -149,7 +149,7 @@ internal class CalculationEngine : ICalculationEngine
 
             var result = new PolygonEtDataCollection
             {
-                WaterConservationApplicationEstimateLocationId = null,
+                WaterConservationApplicationEstimateLocationId = polygon.WaterConservationApplicationEstimateLocationId,
                 PolygonWkt = polygon.PolygonWkt,
                 DrawToolType = polygon.DrawToolType,
                 AverageYearlyTotalEtInInches = averageTotalEtInInches,

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -708,16 +708,7 @@ const onReviewerConsumptiveUseEstimated = (
     const polygon = application.estimateLocations[i];
     const matchingConsumptiveUseData = payload.dataCollections.find((data) => data.polygonWkt === polygon.polygonWkt)!;
 
-    application.estimateLocations[i] = {
-      // preserve existing entry's data
-      ...application.estimateLocations[i],
-      // merge consumptive use data into entry
-      ...matchingConsumptiveUseData,
-      // ensure that the Id is preserved, assuming it exists
-      waterConservationApplicationEstimateLocationId:
-        matchingConsumptiveUseData.waterConservationApplicationEstimateLocationId ??
-        application.estimateLocations[i].waterConservationApplicationEstimateLocationId,
-    };
+    Object.assign(application.estimateLocations[i], matchingConsumptiveUseData);
   }
 
   // update control location


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the backend to appropriately track the polygon id if it is received as part of the reviewer's EstimateConsumptiveUse request. Updated tests.

Updated the frontend to remove the workaround we were performing to track a polygon id since the backend wasn't doing it for us.

## Appearance

demo 1 - showcasing the issue. If we did not have the existing frontend workaround in place to track Ids, we would lose the additional details when running EstimateConsumptiveUse multiple times.

https://github.com/user-attachments/assets/4a767110-e4f0-4429-9bf3-cc6beb0aa382

demo 2 - showcasing the fix. Ids are tracked appropriately, changes are saved appropriately, and we no longer run the risk of losing the additional details fields.

https://github.com/user-attachments/assets/84651343-6b7e-4c2c-adc4-0ae453c3b6d4
