### PR TITLE
Application Review - better handling of polygon field name references & Additional Details inputs

### DIFF
--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -664,7 +664,7 @@ const onApplicantConsumptiveUseEstimated = (
     const polygon = application.estimateLocations[i];
     const matchingConsumptiveUseData = payload.dataCollections.find((data) => data.polygonWkt === polygon.polygonWkt)!;
 
-    polygon.fieldName = generateFieldName(i);
+    polygon.fieldName = generateFieldName(i + 1);
     polygon.waterConservationApplicationEstimateLocationId =
       matchingConsumptiveUseData.waterConservationApplicationEstimateLocationId ?? undefined;
     polygon.averageYearlyTotalEtInInches = matchingConsumptiveUseData.averageYearlyTotalEtInInches;

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -720,7 +720,14 @@ const onReviewerConsumptiveUseEstimated = (
   // ie if "Field 3" exists, start with "Field 4"
   const existingFieldNameIndices = application.estimateLocations
     .filter((location) => !!location.fieldName)
-    .map((location) => Number(location.fieldName!.split(' ')[1]));
+    .map((location): number => {
+      // validate field name was generated in expected format
+      if (!location.fieldName!.startsWith('Field ')) {
+        throw new Error(`Field name ${location.fieldName} is not in expected format`);
+      }
+
+      return Number(location.fieldName!.split(' ')[1]);
+    });
   const maxFieldNameIndex = existingFieldNameIndices.reduce((prev, curr) => Math.max(prev, curr), 0);
 
   let assignedFieldNameIndex = maxFieldNameIndex + 1;

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -664,7 +664,7 @@ const onApplicantConsumptiveUseEstimated = (
     const polygon = application.estimateLocations[i];
     const matchingConsumptiveUseData = payload.dataCollections.find((data) => data.polygonWkt === polygon.polygonWkt)!;
 
-    polygon.fieldName = `Field ${i + 1}`;
+    polygon.fieldName = generateFieldName(i);
     polygon.waterConservationApplicationEstimateLocationId =
       matchingConsumptiveUseData.waterConservationApplicationEstimateLocationId ?? undefined;
     polygon.averageYearlyTotalEtInInches = matchingConsumptiveUseData.averageYearlyTotalEtInInches;

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -723,10 +723,15 @@ const onReviewerConsumptiveUseEstimated = (
     .map((location): number => {
       // validate field name was generated in expected format
       if (!location.fieldName!.startsWith('Field ')) {
-        throw new Error(`Field name ${location.fieldName} is not in expected format`);
+        console.error(`Field name ${location.fieldName} is not in expected format`);
       }
 
-      return Number(location.fieldName!.split(' ')[1]);
+      // handle field number being in unexpected format
+      let fieldNumber: number = Number(location.fieldName!.split(' ')[1]);
+      if (isNaN(fieldNumber)) {
+        fieldNumber = conservationApplicationMaxPolygonCount;
+      }
+      return fieldNumber;
     });
   const maxFieldNameIndex = existingFieldNameIndices.reduce((prev, curr) => Math.max(prev, curr), 0);
 

--- a/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
+++ b/src/DashboardUI/src/contexts/ConservationApplicationState.tsx
@@ -733,7 +733,7 @@ const onReviewerConsumptiveUseEstimated = (
 
     // update field name
     if (!polygon.fieldName) {
-      polygon.fieldName = `Field ${assignedFieldNameIndex}`;
+      polygon.fieldName = generateFieldName(assignedFieldNameIndex);
       assignedFieldNameIndex++;
     }
   }
@@ -878,7 +878,7 @@ const onApplicationLoaded = (
       drawToolType: location.drawToolType,
       acreage: location.polygonAreaInAcres,
       additionalDetails: location.additionalDetails ?? '',
-      fieldName: `Field ${index + 1}`,
+      fieldName: generateFieldName(index + 1),
       datapoints: location.waterMeasurements,
       centerPoint: truncate(center(convertWktToGeometry(location.polygonWkt))).geometry,
       // this info is not stored in the db, so it cannot be hydrated into state. it comes from the ET data
@@ -1105,4 +1105,8 @@ const onApplicationReviewerNoteAdded = (
 const onDataTableToggled = (draftState: ConservationApplicationState): ConservationApplicationState => {
   draftState.displayDataTable = !draftState.displayDataTable;
   return draftState;
+};
+
+const generateFieldName = (index: number): string => {
+  return `Field ${index}`;
 };


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [x] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated state to handle polygon changes, and specifically their generated field names, more consistently.

## Appearance

demo 1 - the issue
field names are not generated when the reviewer estimates consumptive use. data mismatch occurs regarding the "additional details" fields when comparing state before and after a refresh.

https://github.com/user-attachments/assets/c4f5b3d9-4878-4b95-b971-ab5f4cdfec91

demo 2 - the fix
field names are generated when the reviewer estimates consumptive use, and they are generated in a way that avoids potential data conflicts with the "additional details" fields. no data mismatch occurs between refreshes

https://github.com/user-attachments/assets/d91a4e9b-5734-4030-9202-347f00e53f6a
