### PR TITLE
constrain label placement on map

### DIFF
--- a/src/DashboardUI/src/config/maps.ts
+++ b/src/DashboardUI/src/config/maps.ts
@@ -351,7 +351,7 @@ const mapsJson: {
           'top',
           'bottom',
         ],
-        'text-radial-offset': 0.5,
+        'text-radial-offset': 0.5, // how far outward from the center the text is placed
         'text-size': 20,
         'text-justify': 'center',
         'text-letter-spacing': 0.05, // default is 0

--- a/src/DashboardUI/src/config/maps.ts
+++ b/src/DashboardUI/src/config/maps.ts
@@ -300,7 +300,7 @@ const mapsJson: {
       type: 'symbol',
       filter: ['==', ['get', 'westdaat_pointdatasource'], 'Location'],
     },
-      {
+    {
       id: mapLayerNames.timeSeriesPolygonsLayer,
       friendlyName: 'Time Series Polygons',
       'source-layer': 'polygons',
@@ -344,9 +344,14 @@ const mapsJson: {
       type: 'symbol',
       source: mapSourceNames.userDrawnPolygonLabelsGeoJson,
       layout: {
-        'text-field': ['get', 'title'],
+        'text-field': ['get', 'title'], // displays the `title` property
         'text-font': ['Open Sans Bold'], // default is `Open Sans Regular`
-        'text-variable-anchor': ['top', 'bottom', 'left', 'right'],
+        'text-variable-anchor': [
+          // locations where the text can be placed
+          'top',
+          'bottom',
+        ],
+        'text-radial-offset': 0.5,
         'text-size': 20,
         'text-justify': 'center',
         'text-letter-spacing': 0.05, // default is 0


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the map to push labels slightly away from the point they're attached to, and limited labels to only appearing directly above or below their point.

**note**: This change impacts both the polygons and the control points. We'd have to rework the control point rendering a bit if we wanted to decouple these. Currently, I'm not convinced that would be worth it.

## Appearance

Currently, labels are pushed away **0.5 em** from their point. Here's some examples of what different values look like:

0 (default) | 0.5 (current) | 1 | 3
:---: | :---: | :---: | :---:
![image](https://github.com/user-attachments/assets/3fa6d432-6dce-4cd2-8887-fd6285d7178b) | ![image](https://github.com/user-attachments/assets/2345e281-40f9-46bc-9775-592c246fd265) | ![image](https://github.com/user-attachments/assets/58913b0a-744e-4c11-8789-ed2d3588f286) | ![image](https://github.com/user-attachments/assets/a1b8e749-a529-4aaa-b02b-f79264c84d3d)