### PR TITLE
Updated Request Validators

### DIFF
--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicantEstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ApplicantEstimateConsumptiveUseRequestValidator.cs
@@ -14,7 +14,7 @@ public class ApplicantEstimateConsumptiveUseRequestValidator : AbstractValidator
         RuleForEach(x => x.Polygons).ChildRules(polygonEntryValidator =>
         {
             polygonEntryValidator.RuleFor(polygon => polygon).NotNull();
-            polygonEntryValidator.RuleFor(polygon => polygon.PolygonWkt).NotEmpty();
+            polygonEntryValidator.RuleFor(polygon => polygon.PolygonWkt).NotEmpty().MaximumLength(4000);
             polygonEntryValidator.RuleFor(polygon => polygon.DrawToolType).NotEmpty();
         });
 

--- a/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
+++ b/src/API/WesternStatesWater.WestDaat.Contracts.Client/Requests/Conservation/ReviewerEstimateConsumptiveUseRequestValidator.cs
@@ -12,7 +12,7 @@ public class ReviewerEstimateConsumptiveUseRequestValidator : AbstractValidator<
         RuleForEach(x => x.Polygons).ChildRules(polygonEntryValidator =>
         {
             polygonEntryValidator.RuleFor(polygon => polygon).NotNull();
-            polygonEntryValidator.RuleFor(polygon => polygon.PolygonWkt).NotEmpty();
+            polygonEntryValidator.RuleFor(polygon => polygon.PolygonWkt).NotEmpty().MaximumLength(4000);
             polygonEntryValidator.RuleFor(polygon => polygon.DrawToolType).NotEmpty();
         });
 


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [x] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated request validators for applicant/reviewer `EstimateConsumptiveUse` requests to ensure polygon wkts conform to the maximum length constraints imposed by the db table `EstimateLocations`

## Appearance
no change