### PR TITLE
Limit Geometry Precision

### DIFF
--- a/src/DashboardUI/src/components/map/Map.tsx
+++ b/src/DashboardUI/src/components/map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import mapboxgl, {
   LayerSpecification,
   GeoJSONSourceSpecification,
@@ -23,7 +23,6 @@ import { useDrop } from 'react-dnd';
 import { useDebounce, useDebounceCallback } from '@react-hook/debounce';
 import { CustomShareControl } from './CustomShareControl';
 import { CustomFitControl } from './CustomFitControl';
-import ReactDOM from 'react-dom';
 import { FeatureCollection, Feature, GeoJsonProperties, Geometry, Point } from 'geojson';
 import { useHomePageContext } from '../home-page/Provider';
 import { createRoot } from 'react-dom/client';
@@ -35,6 +34,7 @@ import { Alert } from 'react-bootstrap';
 import Icon from '@mdi/react';
 import { isFeatureEnabled } from '../../config/features';
 import { DrawBarButton, ExtendedMapboxDraw } from './ExtendedMapboxDraw';
+import truncate from '@turf/truncate';
 
 import './map.scss';
 
@@ -209,7 +209,14 @@ function Map({
 
     const callback = () => {
       if (handleMapDrawnPolygonChange) {
-        handleMapDrawnPolygonChange(dc.getAll().features);
+        const allFeatures = dc.getAll().features;
+
+        for (const feature of allFeatures) {
+          // limit decimal precision
+          feature.geometry = truncate(feature.geometry, { precision: 6 });
+        }
+
+        handleMapDrawnPolygonChange(allFeatures);
       }
     };
 

--- a/src/DashboardUI/src/utilities/geometryHelpers.ts
+++ b/src/DashboardUI/src/utilities/geometryHelpers.ts
@@ -39,9 +39,8 @@ export const generateCircleWithRadiusFromCenterPointToEdgePoint = (
     units: 'kilometers',
   });
   const circleFeature = circle(circleCenterPoint, distanceFromCenterToEdgeInKm, { steps: 100 });
-  // `circle` generates coordinates with up to 14 decimal places of precision.
-  // 7 decimals is worth up to 1.1cm of precision, which is more than enough for our purposes.
-  return truncate(circleFeature, { precision: 7 });
+  // limit geometry precision to save space
+  return truncate(circleFeature, { precision: 6 });
 };
 
 export const doPolygonsIntersect = (polygons: Feature<Geometry, GeoJsonProperties>[]): boolean => {


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [ ] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Updated the map to limit all geometry precision to 6 decimal points. This fixes an error where the `polygonWkt` length limit was being hit.

no change in appearance.