### PR TITLE
Fix Water Site/Right and Home Page Toast Messages

### DIFF
--- a/src/DashboardUI/src/hooks/useProgressIndicator.ts
+++ b/src/DashboardUI/src/hooks/useProgressIndicator.ts
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { toast, ToastContent } from 'react-toastify';
+import { useEffect, useMemo } from 'react';
+import { Id, toast, ToastContent } from 'react-toastify';
 
 function useProgressIndicator(progress: number | boolean[], content: ToastContent) {
-  const toastContainer = document.querySelector('#app-toast-container');
-  const loadingFilterDataToast = useRef<string | number | null>(null);
+  let toastId: Id | null = null;
 
   const calculatedProgress = useMemo(() => {
     if (Array.isArray(progress)) {
@@ -13,27 +12,20 @@ function useProgressIndicator(progress: number | boolean[], content: ToastConten
   }, [progress]);
 
   useEffect(() => {
-    // Wait for the toast container to be available in the dom.
-    // If you don't, then toast messages on initial page load will not show.
-    if (toastContainer == null) {
-      return;
+    if (toastId === null) {
+      toastId = toast.info(content);
+    } else {
+      if (calculatedProgress < 1) {
+        toast.update(toastId, {
+          progress: calculatedProgress,
+          autoClose: false,
+          type: 'info',
+          theme: 'colored',
+        });
+      } else {
+        toast.dismiss(toastId);
+      }
     }
-
-    if (loadingFilterDataToast.current == null && calculatedProgress < 1) {
-      loadingFilterDataToast.current = toast.info(content, {
-        progress: calculatedProgress,
-        autoClose: false,
-        type: 'info',
-        theme: 'colored',
-      });
-    } else if (loadingFilterDataToast.current != null && calculatedProgress < 1) {
-      toast.update(loadingFilterDataToast.current!, {
-        progress: calculatedProgress,
-      });
-    } else if (loadingFilterDataToast.current != null) {
-      toast.dismiss(loadingFilterDataToast.current!);
-      loadingFilterDataToast.current = null;
-    }
-  }, [calculatedProgress, content, toastContainer]);
+  }, [calculatedProgress, content, toastId]);
 }
 export default useProgressIndicator;

--- a/src/DashboardUI/src/hooks/useProgressIndicator.ts
+++ b/src/DashboardUI/src/hooks/useProgressIndicator.ts
@@ -1,8 +1,8 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Id, toast, ToastContent } from 'react-toastify';
 
 function useProgressIndicator(progress: number | boolean[], content: ToastContent) {
-  let toastId: Id | null = null;
+  const [toastId, setToastId] = useState<Id | null>(null);
 
   const calculatedProgress = useMemo(() => {
     if (Array.isArray(progress)) {
@@ -11,9 +11,17 @@ function useProgressIndicator(progress: number | boolean[], content: ToastConten
     return progress;
   }, [progress]);
 
+
   useEffect(() => {
     if (toastId === null) {
-      toastId = toast.info(content);
+      if (calculatedProgress < 1) {
+        const id = toast.info(content, {
+          autoClose: false,
+          type: 'info',
+          theme: 'colored'
+        });
+        setToastId(id);
+      }
     } else {
       if (calculatedProgress < 1) {
         toast.update(toastId, {
@@ -26,6 +34,6 @@ function useProgressIndicator(progress: number | boolean[], content: ToastConten
         toast.dismiss(toastId);
       }
     }
-  }, [calculatedProgress, content, toastId]);
+  }, [progress, content]);
 }
 export default useProgressIndicator;


### PR DESCRIPTION
## Description

The toast messages on various landing pages were not appearing.  This PR fixes that.

This bug was introduced when fixing all other toast messages. These pages all use the same utility (`useProgressIndicator`) to display their toasts, and the `useProgressIndicator` was trying to find a toast container by id (which was removed in the previous fix).

- Home page: `/`
- Water Site landing page: `/details/site/:id`
- Water Right landing page: `/details/right/:id`

## Demo

<details><summary>🎥 Home Page</summary>

https://github.com/user-attachments/assets/f7a0d493-e9af-4c66-86b7-2e253d89b5bc

</details>
<details><summary>🎥 Water Right</summary>

https://github.com/user-attachments/assets/bad8e819-331a-4176-bc2b-c196cac5a440

</details>
<details><summary>🎥 Water Site</summary>

https://github.com/user-attachments/assets/f38f6cf8-77fb-4646-ad23-72e931dfbdc0

</details>

---

Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?
