### PR TITLE
Review Map - zoom should include control location

### DIFF
--- a/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolMap.tsx
+++ b/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolMap.tsx
@@ -85,7 +85,7 @@ export function EstimationToolMap(props: EstimationToolMapProps) {
 
     setMapBoundSettings({
       LngLatBounds: getLatsLongsFromFeatureCollection(userDrawnPolygonFeatureCollection),
-      padding: 25,
+      padding: 200,
       maxZoom: 16,
     });
   }, [
@@ -136,7 +136,7 @@ export function EstimationToolMap(props: EstimationToolMapProps) {
     };
     setMapBoundSettings({
       LngLatBounds: getLatsLongsFromFeatureCollection(allFeaturesFeatureCollection),
-      padding: 25,
+      padding: 200,
       maxZoom: 16,
       duration: 5000,
     });

--- a/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
+++ b/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
@@ -169,7 +169,7 @@ function ReviewMap(props: ReviewMapProps) {
     };
     setMapBoundSettings({
       LngLatBounds: getLatsLongsFromFeatureCollection(allFeaturesFeatureCollection),
-      padding: 25,
+      padding: 200,
       maxZoom: 16,
       duration: 5000,
     });

--- a/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
+++ b/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
@@ -115,7 +115,7 @@ function ReviewMap(props: ReviewMapProps) {
     };
     setMapBoundSettings({
       LngLatBounds: getLatsLongsFromFeatureCollection(allFeaturesCollection),
-      padding: 25,
+      padding: 200,
       maxZoom: 16,
       duration: 2000,
     });

--- a/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
+++ b/src/DashboardUI/src/pages/application/review/map/ReviewMap.tsx
@@ -108,13 +108,13 @@ function ReviewMap(props: ReviewMapProps) {
     ];
     setUserDrawnPolygonData(allFeatures);
 
-    // zoom map in to focus on polygons
-    const userDrawnPolygonFeatureCollection: FeatureCollection<Geometry, GeoJsonProperties> = {
+    // zoom map in to focus on polygons + control location
+    const allFeaturesCollection: FeatureCollection<Geometry, GeoJsonProperties> = {
       type: 'FeatureCollection',
-      features: userDrawnPolygonFeatures,
+      features: allFeatures,
     };
     setMapBoundSettings({
-      LngLatBounds: getLatsLongsFromFeatureCollection(userDrawnPolygonFeatureCollection),
+      LngLatBounds: getLatsLongsFromFeatureCollection(allFeaturesCollection),
       padding: 25,
       maxZoom: 16,
       duration: 2000,


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [ ] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
fixed bug where review map zoom-in did not include the control point. it now considers the control point's position when zooming in.

## Appearance

https://github.com/user-attachments/assets/040bafce-79c3-4bf8-8886-07950ac196f8
