### PR TITLE
Static Map Image - Field Labels Bugfix

### DIFF
--- a/src/DashboardUI/src/hooks/queries/useApplicationQuery.ts
+++ b/src/DashboardUI/src/hooks/queries/useApplicationQuery.ts
@@ -190,32 +190,34 @@ export function useReviewerEstimateConsumptiveUseMutation() {
             type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_STARTED',
           });
 
-          mapContext
-            .exportToPngFn({
+          // artificial delay to allow the field labels to render
+          setTimeout(() => {
+            mapContext.exportToPngFn!({
               height: 400,
               width: 600,
             })
-            .then((blob) => {
-              const applicationId = state.conservationApplication.waterConservationApplicationId;
-              if (blob && applicationId) {
-                const file = new File([blob], `${applicationId}.png`, { type: blob.type });
-                uploadApplicationStaticMap(msalContext, file, applicationId);
+              .then((blob) => {
+                const applicationId = state.conservationApplication.waterConservationApplicationId;
+                if (blob && applicationId) {
+                  const file = new File([blob], `${applicationId}.png`, { type: blob.type });
+                  uploadApplicationStaticMap(msalContext, file, applicationId);
 
-                blobToBase64(blob).then((base64) => {
-                  dispatch({
-                    type: 'APPLICATION_MAP_STATIC_IMAGE_ADDED',
-                    payload: {
-                      mapImageUrl: base64,
-                    },
+                  blobToBase64(blob).then((base64) => {
+                    dispatch({
+                      type: 'APPLICATION_MAP_STATIC_IMAGE_ADDED',
+                      payload: {
+                        mapImageUrl: base64,
+                      },
+                    });
                   });
+                }
+              })
+              .finally(() => {
+                dispatch({
+                  type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_COMPLETED',
                 });
-              }
-            })
-            .finally(() => {
-              dispatch({
-                type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_COMPLETED',
               });
-            });
+          }, 1500);
         }
       }
     },

--- a/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolPage.tsx
+++ b/src/DashboardUI/src/pages/application/estimation-tool/EstimationToolPage.tsx
@@ -81,31 +81,34 @@ export function EstimationToolPage() {
             type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_STARTED',
           });
 
-          mapContext.exportToPngFn!({
-            height: 400,
-            width: 600,
-          })
-            .then((blob) => {
-              const applicationId = state.conservationApplication.waterConservationApplicationId;
-              if (blob && applicationId) {
-                const file = new File([blob], `${applicationId}.png`, { type: blob.type });
-                uploadApplicationStaticMap(context, file, applicationId);
-
-                blobToBase64(blob).then((base64) => {
-                  dispatch({
-                    type: 'APPLICATION_MAP_STATIC_IMAGE_ADDED',
-                    payload: {
-                      mapImageUrl: base64,
-                    },
-                  });
-                });
-              }
+          // artificial delay to allow the field labels to render
+          setTimeout(() => {
+            mapContext.exportToPngFn!({
+              height: 400,
+              width: 600,
             })
-            .finally(() => {
-              dispatch({
-                type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_COMPLETED',
+              .then((blob) => {
+                const applicationId = state.conservationApplication.waterConservationApplicationId;
+                if (blob && applicationId) {
+                  const file = new File([blob], `${applicationId}.png`, { type: blob.type });
+                  uploadApplicationStaticMap(context, file, applicationId);
+
+                  blobToBase64(blob).then((base64) => {
+                    dispatch({
+                      type: 'APPLICATION_MAP_STATIC_IMAGE_ADDED',
+                      payload: {
+                        mapImageUrl: base64,
+                      },
+                    });
+                  });
+                }
+              })
+              .finally(() => {
+                dispatch({
+                  type: 'APPLICATION_MAP_STATIC_IMAGE_GENERATE_COMPLETED',
+                });
               });
-            });
+          }, 1500);
         }
       }
     },


### PR DESCRIPTION
Pull Request Checklist

- [x] Did you pull latest and merge `develop` (or `master`) into your branch?
- [ ] Did you add tests?
- [x] Did you run the front-end tests (if applicable)?
- [ ] Did you run the back-end tests (if applicable)?
- [x] Did you include screenshots or a demo video (if applicable)?
- [x] Did you include a descriptive title and description with your PR?
- [x] Did you perform a self-review before assigning reviewers?

## Summary
Added an artificial delay to the beginning of the static map image generation so that the field labels on the map have time to be rendered.

## Appearance

This demo video showcases the happy path - the static map image generation works, and the field labels are included

https://github.com/user-attachments/assets/130cf511-63ec-45dc-9232-ef2a3acb58a8

---

This next demo video also showcases the happy path, but highlights a quirk with how mapbox chooses to render field labels.

If two or more labels are too close to each other, and if the map cannot zoom in more, then some of those labels may be hidden automatically by mapbox because mapbox detects that there is insufficient space to display those labels. This is expected behavior from mapbox, but I'm including this demo as additional context because I'm not sure if we want this behavior for the static map images.

https://github.com/user-attachments/assets/922932b0-3207-491a-aae8-850c2dc69e1c
